### PR TITLE
Efficient Sampler for Quantum Interface

### DIFF
--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -227,9 +227,10 @@ class QuantumInterface:
         values = 0.0
         observables = self.op_to_qbit(op)
 
-        # Loop over all clique Paulies
+        # Obtain cliques for operator's Pauli strings
         cliques = make_cliques(observables.paulis)
         distributions = {}
+        # Simulate each clique Pauli String
         for clique_pauli, clique in cliques.items():
             dist = self._sampler_distributions(Pauli(clique_pauli), run_parameters)
             # It is wasteful to store the distribution per Pauli instead of per Clique,

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -137,6 +137,8 @@ class QuantumInterface:
                 "The length of the parameter list does not fit the chosen circuit for the Ansatz ",
                 self.ansatz,
             )
+        if hasattr(self, "distributions"):
+            self.distributions.clear()
         self._parameters = parameters.copy()
 
     def op_to_qbit(self, op: FermionicOperator) -> SparsePauliOp:

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -200,7 +200,7 @@ class QuantumInterface:
             self.total_shots_used += self._primitive.options.shots
         elif "execution" in self._primitive.options:
             # Device
-            self.total_shots_used += self._primitive.options["execution"]["shots"]
+            self.total_shots_used += self._primitive.options["execution"]["shots"] * len(observables)
         self.total_device_calls += 1
         self.total_paulis_evaluated += len(observables)
         result = job.result()

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -230,9 +230,12 @@ class QuantumInterface:
         values = 0.0
         # Map Fermionic to Qubit
         observables = self.op_to_qbit(op)
-
         # Obtain cliques for operator's Pauli strings
         raw_cliques = make_cliques(observables.paulis)
+        # Make sure clique head is in clique Pauli list
+        for clique_pauli, clique in raw_cliques.items():
+            if clique_pauli not in clique:
+                clique.append(clique_pauli)
         cliques = {}
 
         if not hasattr(self, "distributions"):
@@ -244,16 +247,14 @@ class QuantumInterface:
                 cliques[clique_pauli] = clique
 
         if len(cliques) != 0:
-            # Simulate each clique Pauli String with one combined device call
+            # Simulate each clique head with one combined device call
             # and return a list of distributions
             distr = self._one_call_sampler_distributions(PauliList(list(cliques.keys())), run_parameters)
 
-            # Loop over all cliques and their commuting Pauli strings to obtain the result for each Pauli string
+            # Loop over all clique Paul lists to obtain the result for each Pauli string from the clique head distribution
             for nr, clique in enumerate(cliques.values()):
-                dist = distr[nr]  # Measured distribution for a given clique
-                # It is wasteful to store the distribution per Pauli instead of per clique,
-                # but it help unpack it later.
-                for pauli in clique:  # Loop over all Pauli strings associated with one clique
+                dist = distr[nr]  # Measured distribution for a given clique head
+                for pauli in clique:  # Loop over all clique Pauli strings associated with one clique head
                     result = 0.0
                     for key, value in dist.items():  # build result from quasi-distribution
                         # Here we could check if we want a given key (bitstring) in the result distribution

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -197,7 +197,7 @@ class QuantumInterface:
         )
         if hasattr(self._primitive.options, "shots"):
             # Shot-noise simulator
-            self.total_shots_used += self._primitive.options.shots
+            self.total_shots_used += self._primitive.options.shots * len(observables)
         elif "execution" in self._primitive.options:
             # Device
             self.total_shots_used += self._primitive.options["execution"]["shots"] * len(observables)

--- a/slowquant/qiskit_interface/wavefunction.py
+++ b/slowquant/qiskit_interface/wavefunction.py
@@ -287,6 +287,8 @@ class WaveFunction:
         self._rdm3 = None
         self._rdm4 = None
         self._energy_elec = None
+        self.QI.total_device_calls = 0
+        self.QI.total_shots_used = 0
         self.QI._primitive = primitive  # pylint: disable=protected-access
 
     @property
@@ -406,6 +408,29 @@ class WaveFunction:
             H = H.get_folded_operator(self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs)
             self._energy_elec = calc_energy_theta(self.ansatz_parameters, H, self.QI)
         return self._energy_elec
+
+    def _calc_energy_elec(self) -> float:
+        """Run electronic energy simulation, regardless of self.energy_elec variable.
+
+        Returns:
+            Electronic energy.
+        """
+        H = hamiltonian_pauli_0i_0a(self.h_mo, self.g_mo, self.num_inactive_orbs, self.num_active_orbs)
+        H = H.get_folded_operator(self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs)
+        energy_elec = calc_energy_theta(self.ansatz_parameters, H, self.QI)
+
+        return energy_elec
+
+    def _get_hamiltonian(self) -> FermionicOperator:
+        """Return electronic Hamiltonian as FermionicOperator.
+
+        Returns:
+            FermionicOperator.
+        """
+        H = hamiltonian_pauli_0i_0a(self.h_mo, self.g_mo, self.num_inactive_orbs, self.num_active_orbs)
+        H = H.get_folded_operator(self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs)
+
+        return H
 
     def run_vqe_2step(
         self,

--- a/slowquant/qiskit_interface/wavefunction.py
+++ b/slowquant/qiskit_interface/wavefunction.py
@@ -289,6 +289,8 @@ class WaveFunction:
         self._energy_elec = None
         self.QI.total_device_calls = 0
         self.QI.total_shots_used = 0
+        self.QI.total_paulis_evaluated = 0
+        self.QI.distributions = {}
         self.QI._primitive = primitive  # pylint: disable=protected-access
 
     @property


### PR DESCRIPTION
Re-write quantum interface sampler to reduce overhead of device calls and amount of Pauli strings simulations.
Sampler uses QWC, groups circuits to single sampler run, and stores unique Pauli strings. 