### PR TITLE
Quantum Interface for superposition states

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: 24.8.0
     hooks:
       - id: black
+        args: ["--target-version", "py312"]
         additional_dependencies:
           - toml
 

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -308,6 +308,8 @@ class QuantumInterface:
         Args:
             pass_manager: PassManager object from Qiskit.
         """
+        if pass_manager is not None and isinstance(pass_manager, PassManager):
+            raise ValueError("The pass_manager argument has to be a tuple of PassManager and Backend.")
         self._internal_pm = False
         if not self.ISA and isinstance(pass_manager, tuple):
             raise ValueError("You need to enable ISA if you want to use a custom PassManager.")

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -323,6 +323,9 @@ class QuantumInterface:
             )
             self._pass_manager: None | PassManager = pass_manager[0]
             self._pm_backend = pass_manager[1]
+            # Way to extract coupling map and basis gates. Not noise!
+            # It is needed to create the init_indices and final_indices off-spring pass_managers.
+            # It would be great if this info could get extracted. For now - not possible.
         # Default pass manager
         elif self.ISA and not isinstance(pass_manager, tuple):
             self._internal_pm = True
@@ -462,13 +465,13 @@ class QuantumInterface:
             # Create a pass manager that maps on the Ansatz Circuit qubits in the initial layout (no swaps)
             if hasattr(self, "_pm_backend"):
                 self._initialfixedlayout_pm = generate_preset_pass_manager(
-                    1,  # needs level 1 to work with layout-conserving composing
+                    3,  # needs level 1 to work with layout-conserving composing
                     backend=self._pm_backend,
                     initial_layout=self._circuit_indices,
                 )
             else:
                 self._initialfixedlayout_pm = generate_preset_pass_manager(
-                    1,  # needs level 1 to work with layout-conserving composing
+                    3,  # needs level 1 to work with layout-conserving composing
                     backend=self._primitive_backend,
                     initial_layout=self._circuit_indices,
                 )
@@ -720,6 +723,7 @@ class QuantumInterface:
                 ISA_csfs_option = 4  # could also use 2
                 if self.do_M_ansatz0:
                     ISA_csfs_option = 3
+        print(ISA_csfs_option)
         if custom_parameters is None:
             run_parameters = self.parameters
         else:

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -723,7 +723,7 @@ class QuantumInterface:
                 ISA_csfs_option = 4  # could also use 2
                 if self.do_M_ansatz0:
                     ISA_csfs_option = 3
-        print(ISA_csfs_option)
+        print("CSFS expectation value with circuit composing option: ", ISA_csfs_option)
         if custom_parameters is None:
             run_parameters = self.parameters
         else:
@@ -1447,12 +1447,15 @@ class QuantumInterface:
             )
         if self.ISA:
             data += f"\n {'Circuit layout:':<20} {self._measurement_indices}"
+            data += f"\n {'Non-local gates:':<20} {self.ansatz_circuit.num_nonlocal_gates()}"
             if self._internal_pm:
                 data += f"\n {'Transpilation strategy:':<20} {'Default / internal'}"
-                data += f"\n {'Transpiled backend:':<20} {self._primitive_backend}\n {'Transpiled opt. level:':<20} {self._primitive_level}"
+                data += f"\n {'Backend:':<20} {self._primitive_backend}\n {'Transpiled opt. level:':<20} {self._primitive_level}"
             else:
                 data += f"\n {'Transpilation strategy:':<20} {'External PassManager'}"
-                data += f"\n {'Transpiled backend:':<20} {self._pm_backend}\n"
+                data += f"\n {'Transpilation backend:':<20} {self._pm_backend}"
+                if hasattr(self, "_primitive_backend"):
+                    data += f"\n {'Primitive backend:':<20} {self._primitive_backend}\n"
             if isinstance(self._primitive, BaseSamplerV2) and hasattr(self._primitive.options, "twirling"):
                 data += f"\n {'Pauli twirling:':<20} {self._primitive.options.twirling.enable_gates}\n {'Dynamic decoupling:':<20} {self._primitive.options.dynamical_decoupling.enable}"
         print(data)

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -1085,7 +1085,8 @@ class QuantumInterface:
         if overwrite_indices is not None:
             measurement_indices = overwrite_indices
         else:
-            measurement_indices = self._measurement_indices
+            if self.ISA:
+                measurement_indices = self._measurement_indices
 
         # Check V1 vs. V2
         if isinstance(self._primitive, BaseSamplerV2):
@@ -1099,7 +1100,9 @@ class QuantumInterface:
                 pauli_circuit = to_CBS_measurement(pauli, self._transp_xy)
                 for nr_circuit, circuit in enumerate(circuits_in):
                     # Add measurement in correct layout
-                    ansatz_w_obs = circuit.compose(pauli_circuit, qubits=measurement_indices)
+                    ansatz_w_obs = circuit.compose(
+                        pauli_circuit, qubits=measurement_indices  # pylint: disable=E0606
+                    )
                     # Create classic register and measure relevant qubits
                     ansatz_w_obs.add_register(ClassicalRegister(self.num_qubits, name="meas"))
                     ansatz_w_obs.measure(measurement_indices, np.arange(self.num_qubits))

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -725,7 +725,7 @@ class QuantumInterface:
         # Option handling
         if ISA_csfs_option == 0:
             ISA_csfs_option = 1
-            if self.do_M_mitigation:
+            if self.do_M_mitigation and self.ansatz_circuit.layout is not None:
                 ISA_csfs_option = 2
                 if self.do_M_ansatz0:
                     ISA_csfs_option = 3  # could also be 4

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -317,22 +317,23 @@ class QuantumInterface:
                 "Warning: Using custom pass manager is an experimental feature if used together with the quantum_expectation_value_csfs function, as requiered for SA wave functions."
             )
             self._pass_manager: None | PassManager = pass_manager[0]
-            self._layoutfree_pm = generate_preset_pass_manager(
-                self._primitive_level,
-                backend=pass_manager[1],
-                layout_method="trivial",
-            )
+            self._backend = pass_manager[1]
+            # self._layoutfree_pm = generate_preset_pass_manager(
+            #     self._primitive_level,
+            #     backend=pass_manager[1],
+            #     layout_method="trivial",
+            # )
         # Default pass manager
         elif self.ISA and not isinstance(pass_manager, tuple):
             self._internal_pm = True
             self._pass_manager = generate_preset_pass_manager(
                 self._primitive_level, backend=self._primitive_backend
             )
-            self._layoutfree_pm = generate_preset_pass_manager(
-                self._primitive_level,
-                backend=self._primitive_backend,
-                layout_method="trivial",
-            )
+            # self._layoutfree_pm = generate_preset_pass_manager(
+            #     self._primitive_level,
+            #     backend=self._primitive_backend,
+            #     layout_method="trivial",
+            # )
             print(
                 f"You selected ISA but did not pass a PassManager. Standard internal transpilation will use backend {self._primitive_backend} with optimization level {self._primitive_level}"
             )
@@ -444,6 +445,9 @@ class QuantumInterface:
             self.pass_manager.optimization.run(self.pass_manager.translation.run(to_CBS_measurement("X"))),
             self.pass_manager.optimization.run(self.pass_manager.translation.run(to_CBS_measurement("Y"))),
         ]
+
+        # Create a pass manager that always maps on the Ansatz Circuit qubits!
+        # Open Question: Which indices?
 
         return circuit_return
 

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -324,7 +324,6 @@ class QuantumInterface:
 
         Args:
             pass_manager_options: Dictionary with pass manager options to update.
-
         """
         if pass_manager_options is not None:
             # Update pass_manager_options
@@ -346,7 +345,7 @@ class QuantumInterface:
         ]
         if len(wrong_items) > 0:
             raise ValueError(
-                "The specified pass manager options do not exists. YOu have specified",
+                "The specified pass manager options do not exist. You have specified",
                 wrong_items,
                 " which is not in allowed options",
                 allowed_pm_options,
@@ -616,13 +615,12 @@ class QuantumInterface:
         """Check if a circuit has same layout as ansatz circuit/M.
 
         Args:
-            circuit_in: Quantum Circuit
+            circuit_in: Quantum Circuit.
 
         Returns:
-            Integer.
-                0 = no layout - no order conflict
-                1 = no layout, but order conflict
-                2 = layout conflict
+            0 = no layout - no order conflict.
+            1 = no layout, but order conflict.
+            2 = layout conflict.
         """
         if not self.ISA:
             if circuit_in.layout is None:
@@ -716,11 +714,11 @@ class QuantumInterface:
             ket_csf: Ket CSF.
             custom_parameters: Non-default run parameters.
             ISA_csfs_option: Option on how to treat the composing of superposition state and Ansatz:
-                0: Find default basedon on error mitigation. Default without EM: 1
-                1: Allow flexible (changing) layout
-                2: Fixed layout but allow change in order (swaps)
-                3: Fixed layout, fixed order, without optimizing circuit after composing
-                4: Fixed layout, fixed order, with optimizing circuit after composing
+                0: Find default based on error mitigation. Default without EM: 1.
+                1: Allow flexible (changing) layout.
+                2: Fixed layout but allow change in order (swaps).
+                3: Fixed layout, fixed order, without optimizing circuit after composing.
+                4: Fixed layout, fixed order, with optimizing circuit after composing.
             M_per_superpos: A new M_Ansatz0 matrix for each superposition state.
             reverse_csfs_order: If true, the pair-entangled superposition states' order is reversed.
                 This might be relevant as the order can influence the circuit depths.
@@ -750,7 +748,7 @@ class QuantumInterface:
                 ISA_csfs_option = 2
                 if self.do_M_ansatz0:
                     ISA_csfs_option = 4  # could also be 3
-        print("CSFS expectation value with circuit composing option: ", ISA_csfs_option)
+        print("CSFs expectation value with circuit composing option: ", ISA_csfs_option)
 
         if custom_parameters is None:
             run_parameters = self.parameters
@@ -973,7 +971,7 @@ class QuantumInterface:
         Args:
             op: SlowQuant fermionic operator.
             run_parameters: Circuit parameters.
-            run_circuit: Quantum circuit
+            run_circuit: Quantum circuit.
 
         Returns:
             Expectation value of operator.
@@ -1017,7 +1015,7 @@ class QuantumInterface:
 
         Args:
             op: SlowQuant fermionic operator.
-            run_circuit: custum circuit to be run. If not specified, HF+Ansatz circuit is used
+            run_circuit: custom circuit to be run. If not specified, HF+Ansatz circuit is used.
             det: Classify state (determinant) of circuit for Pauli saving.
                 Specified in chemistry form, i.e. left-to-right, alternating alpha and beta.
             circuit_M: custom circuit for M_Ansatz0 (correlation matrix is not stored). If not specified, M0 of Ansatz is used.
@@ -1133,9 +1131,9 @@ class QuantumInterface:
         Args:
             op: SlowQuant fermionic operator.
             run_parameters: Circuit parameters.
-            run_circuit: Quantum Circuit
-            do_cliques: If True, use cliques (QWC)
-            circuit_M: custom circuit for M_Ansatz0
+            run_circuit: Quantum Circuit.
+            do_cliques: If True, use cliques (QWC).
+            circuit_M: Custom circuit for M_Ansatz0.
 
         Returns:
             Expectation value of operator.
@@ -1178,7 +1176,7 @@ class QuantumInterface:
                                 distr[i] = correct_distribution(dist, self._Minv)
                         case 1:  # no layout, but order conflict
                             if self.do_M_ansatz0:
-                                raise ValueError("Detected order conflict. Not possile to do M Ansatz0")
+                                raise ValueError("Detected order conflict. Not possible to do M Ansatz0.")
                             print("Detected order conflict. Applying M re-ordering.")
                             for i, dist in enumerate(distr):
                                 distr[i] = correct_distribution_with_layout_v2(  # maybe v1 is better.
@@ -1571,7 +1569,7 @@ class QuantumInterface:
 
         Args:
             shots: Number of shots if they are meant to differ from QI internal shot number.
-            custom_ansatz: specify custom Ansatz to be used.
+            custom_ansatz: Specify custom Ansatz to be used.
         """
         if self.num_qubits > 8:
             raise ValueError("Current implementation does not scale above 8 qubits?")

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -720,7 +720,7 @@ class QuantumInterface:
             )
         if M_per_superpos and isinstance(self._primitive, BaseEstimator):
             raise ValueError("Base estimator does not support M_Ansatz0")
-        if M_per_superpos + self.do_M_ansatz0 + self.do_M_mitigation < 3:
+        if M_per_superpos and (self.do_M_ansatz0 + self.do_M_mitigation) != 2:
             raise ValueError("You requested M_per_superpos but M error mitigation / M_Ansatz0 was not selected in QI settings.")
         # Option handling
         if ISA_csfs_option == 0:

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -941,13 +941,16 @@ class QuantumInterface:
                         distr[i] = correct_distribution(dist, self._Minv)
                 else:
                     print("Layout mismatch between M and circuit")
+                    print(run_circuit.layout.final_index_layout())
+                    # for i, dist in enumerate(distr):
+                    #     distr[i] = correct_distribution_with_layout(
+                    #         dist,
+                    #         self._Minv,
+                    #         self._measurement_indices,
+                    #         run_circuit.layout.final_index_layout(),
+                    #     )
                     for i, dist in enumerate(distr):
-                        distr[i] = correct_distribution_with_layout(
-                            dist,
-                            self._Minv,
-                            self._measurement_indices,
-                            run_circuit.layout.final_index_layout(),
-                        )
+                        distr[i] = correct_distribution(dist, self._Minv)
             if self.do_postselection:
                 for i, (dist, head) in enumerate(zip(distr, new_heads)):
                     if "X" not in head and "Y" not in head:
@@ -970,6 +973,7 @@ class QuantumInterface:
                         distr[i] = correct_distribution(dist, self._Minv)
                 else:
                     print("Layout mismatch between M and circuit")
+                    print(run_circuit.layout.final_index_layout())
                     for i, dist in enumerate(distr):
                         distr[i] = correct_distribution_with_layout(
                             dist,
@@ -1140,7 +1144,7 @@ class QuantumInterface:
                     ansatz_w_obs = circuit.compose(pauli_circuit, qubits=measurement_indices)
                     # Create classic register and measure relevant qubits
                     ansatz_w_obs.add_register(ClassicalRegister(self.num_qubits, name="meas"))
-                    ansatz_w_obs.measure(circuit.layout.final_index_layout(), np.arange(self.num_qubits))
+                    ansatz_w_obs.measure(measurement_indices, np.arange(self.num_qubits))
                     pubs.append((ansatz_w_obs, run_parameters[nr_circuit]))
             pubs = pubs * self._circuit_multipl
 

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -720,7 +720,6 @@ class QuantumInterface:
                 ISA_csfs_option = 4  # could also use 2
                 if self.do_M_ansatz0:
                     ISA_csfs_option = 3
-        print("ISA csfs option: ", ISA_csfs_option)
         if custom_parameters is None:
             run_parameters = self.parameters
         else:

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -1446,7 +1446,7 @@ class QuantumInterface:
             ansatz = custom_ansatz
         M = np.zeros((2**self.num_qubits, 2**self.num_qubits))
         ansatz_list = [None] * 2**self.num_qubits
-        if self.ISA:
+        if ansatz.layout is not None:
             for nr, comb in enumerate(itertools.product([0, 1], repeat=self.num_qubits)):
                 ansatzX = ansatz.copy()
                 # comb is in qN,qN-1,...,q0

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -659,7 +659,7 @@ class QuantumInterface:
         op: FermionicOperator,
         ket_csf: tuple[list[float], list[str]],
         custom_parameters: list[float] | None = None,
-        ISA_csfs_option: int = 1,
+        ISA_csfs_option: int = 0,
     ) -> float:
         r"""Calculate expectation value using different bra and ket of a Hermitian operator.
 
@@ -692,6 +692,7 @@ class QuantumInterface:
             ket_csf: Ket CSF.
             custom_parameters: Non-default run parameters.
             ISA_csfs_option: Option on how to treat the composing of superposition state and Ansatz:
+                0: Find default fitting error mitigation. Default without EM: 1
                 1: Allow flexible (changing) layout
                 2: Fixed layout but allow change in order (swaps)
                 3: Fixed layout, fixed order, without optimizing circuit after composing
@@ -708,6 +709,12 @@ class QuantumInterface:
             raise ValueError(
                 "quantum_expectation_value_csfs got unsupported Qiskit primitive, {type(self._primitive)}"
             )
+        if ISA_csfs_option == 0:
+            ISA_csfs_option = 1
+            if self.do_M_mitigation:
+                ISA_csfs_option = 4  # could also use 2
+                if self.do_M_ansatz0:
+                    ISA_csfs_option = 3
         if custom_parameters is None:
             run_parameters = self.parameters
         else:

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -760,6 +760,7 @@ class QuantumInterface:
                     circuit = get_determinant_superposition_reference(
                         bra_det, ket_det, self.num_orbs, self.mapper
                     )
+                    self.superpos = circuit
                     # Superposition state contains non-native gates for ISA -> transpilatio needed.
                     if self.ISA:
                         match ISA_csfs_option:
@@ -782,6 +783,7 @@ class QuantumInterface:
                                 raise ValueError("Wrong ISA_csfs_option specified. Needs to be 1,2,3,4.")
                     else:
                         circuit = self.ansatz_circuit.compose(circuit, front=True)
+                    self.composed = circuit
                     if isinstance(self._primitive, BaseEstimator):
                         val += N * self._estimator_quantum_expectation_value(op, run_parameters, self.circuit)
                     if isinstance(self._primitive, (BaseSamplerV1, BaseSamplerV2)):

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -402,10 +402,9 @@ class QuantumInterface:
                 "The length of the parameter list does not fit the chosen circuit for the Ansatz ",
                 self.ansatz,
             )
-        if hasattr(self, "cliques"):
-            # The distributions should only reset if the parameters are actually changed.
-            if not np.array_equal(self._parameters, parameters):
-                self.saver = {}
+        # The distributions should only reset if the parameters are actually changed.
+        if not np.array_equal(self._parameters, parameters):
+            self.saver = {}
         self._parameters = parameters.copy()
 
     @property
@@ -523,8 +522,7 @@ class QuantumInterface:
         """
         # IMPORTANT: Shot number in primitive initialization gets always overwritten by QI!
         self._circuit_multipl = 1
-        if hasattr(self, "cliques"):
-            self._reset_cliques()
+        self._reset_cliques()
         if hasattr(self, "_Minv") and self._Minv is not None:
             self._reset_M()
         # Get shot number form primitive if none defined

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -434,7 +434,7 @@ class QuantumInterface:
 
         circuit_return = self.pass_manager.run(circuit)
         # Get layout indices
-        # Routing can introduce swaps. this is a problem and can change initial vs final layout. 
+        # Routing can introduce swaps. this is a problem and can change initial vs final layout.
         if circuit_return.layout is None:
             self._measurement_indices = np.arange(circuit_return.num_qubits)
             self._circuit_indices = np.arange(circuit_return.num_qubits)
@@ -701,19 +701,21 @@ class QuantumInterface:
                         bra_det, ket_det, self.num_orbs, self.mapper
                     )
                     # Transpile superposition state. All stages needed due to H and CNOTs
-                    all_in_one = True # check which is faster! 
+                    all_in_one = True  # check which is faster!
                     if self.ISA:
                         if all_in_one:
-                            circuit = self._ansatz_circuit_raw.compose(circuit, front=True)
+                            circuit = self.compose(circuit, front=True)
                             circuit = self._fixedlayout_pm.run(
                                 circuit
                             )  # this could also fix the AerSimulator problem?
+                            # Problem: Might change layout from final layout for measurement!
+                            # I need to be able to supress this swapping between initial and final layout!
                             print("final: ", circuit.layout.final_index_layout())
                             print("inital: ", circuit.layout.initial_index_layout(filter_ancillas=True))
                             self.circuit_whole = circuit
                         else:
                             self.circuit_superpos = circuit
-                            circuit = self._fixedlayout_pm.run(circuit)
+                            circuit = self._fixedlayout_pm.run(circuit)  # swap make also a problem here!
                             self.circuit_superpos_transp = circuit
                             # This is a very specific bug-fix for the very specific case of
                             # using ISA with ideal AerSimulator without any pass manager

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -448,6 +448,7 @@ class QuantumInterface:
 
         # Create a pass manager that always maps on the Ansatz Circuit qubits!
         # Open Question: Which indices?
+        # Or do it on spot? - How did I do it in past? -> initial layout pass. 
 
         return circuit_return
 

--- a/slowquant/qiskit_interface/sa_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_wavefunction.py
@@ -54,6 +54,7 @@ class WaveFunctionSA:
             states: States to include in the state-averaged expansion.
                     Tuple of lists containing weights and determinants.
                     Each state in SA can be constructed of several dets.
+                    Ordering: left-to-right, alpha-beta alternating
             quantum_interface: QuantumInterface.
             include_active_kappa: Include active-active orbital rotations.
         """

--- a/slowquant/qiskit_interface/sa_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_wavefunction.py
@@ -828,7 +828,7 @@ class WaveFunctionSA:
             osc_strs[idx] = 2 / 3 * excitation_energy * (td_x**2 + td_y**2 + td_z**2)
         return osc_strs
 
-    def _calc_energy_elec(self, ISA_csfs_option: int = 0) -> float:
+    def _calc_energy_elec(self, ISA_csfs_option: int = 0, M_per_superpos: bool = False) -> float:
         """Run electronic energy simulation.
 
         Args:
@@ -842,7 +842,11 @@ class WaveFunctionSA:
         energy = 0.0
         for coeffs, csf in zip(self.states[0], self.states[1]):
             energy += self.QI.quantum_expectation_value_csfs(
-                (coeffs, csf), H, (coeffs, csf), ISA_csfs_option=ISA_csfs_option
+                (coeffs, csf),
+                H,
+                (coeffs, csf),
+                ISA_csfs_option=ISA_csfs_option,
+                M_per_superpos=M_per_superpos,
             )
 
         return energy / self.num_states

--- a/slowquant/qiskit_interface/sa_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_wavefunction.py
@@ -54,7 +54,7 @@ class WaveFunctionSA:
             states: States to include in the state-averaged expansion.
                     Tuple of lists containing weights and determinants.
                     Each state in SA can be constructed of several dets.
-                    Ordering: left-to-right, alpha-beta alternating
+                    Ordering: left-to-right, alpha-beta alternating.
             quantum_interface: QuantumInterface.
             include_active_kappa: Include active-active orbital rotations.
         """
@@ -834,8 +834,8 @@ class WaveFunctionSA:
 
         Args:
             ISA_csfs_option: Option for how to deal with superposition state circuits.
-            M_per_superpos: Switch on M0 per superposition state
-            rep: Repeat energy calculation for statistics
+            M_per_superpos: Switch on M0 per superposition state.
+            rep: Repeat energy calculation for statistics.
 
         Returns:
             Electronic energy.

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -98,8 +98,8 @@ def swap_indices(num_qubits: int, swap: tuple[int, int]) -> list[int]:
     """Find new bit ordering based on a bit swap.
 
     Args:
-        num_qubits: Number of qubits
-        swap: Swap to be performed
+        num_qubits: Number of qubits.
+        swap: Swap to be performed.
 
     Returns:
         List of new ordering in qubit basis based on swap.
@@ -128,11 +128,11 @@ def find_swaps(new: list[int], ref: list[int]) -> list[tuple[int, int]]:
     """Find swaps to turn new into ref.
 
     Args:
-        new: List to be changed
-        ref: Reference list
+        new: List to be changed.
+        ref: Reference list.
 
     Returns:
-        Swaps to turn list into ref
+        Swaps to turn list into ref.
     """
     swaps = []
     list_in = new.copy()
@@ -284,7 +284,7 @@ def correct_distribution(dist: dict[int, float], M: np.ndarray) -> dict[int, flo
 
     Args:
         dist: Quasi-distribution.
-        M: Correlation martix (inverse).
+        M: Correlation matrix (inverse).
 
     Returns:
         Quasi-distribution corrected by correlation matrix.
@@ -304,18 +304,18 @@ def correct_distribution(dist: dict[int, float], M: np.ndarray) -> dict[int, flo
 def correct_distribution_with_layout_v2(
     dist: dict[int, float], M: np.ndarray, ref_layout: list[int], new_layout: list[int]
 ) -> dict[int, float]:
-    r"""Corrects a quasi-distribution of bitstrings based on a correlation matrix in statevector notation.
+    """Corrects a quasi-distribution of bitstrings based on a correlation matrix in statevector notation.
 
     Uses layout correction via distribution mapping.
 
     Args:
         dist: Quasi-distribution.
-        M: Correlation martix (inverse).
+        M: Correlation matrix (inverse).
         ref_layout: Reference layout of M measurement.
         new_layout: Layout of current to be corrected circuit measurement.
 
     Returns:
-        Quasi-distribution corrected by correlation matrix with corrected layout
+        Quasi-distribution corrected by correlation matrix with corrected layout.
     """
     # Find swaps that map new layout to reference layout
     # Layout indices need to be inverted due to qiskit saving layout indices q0->qN and distribtions qN->q0.
@@ -335,26 +335,26 @@ def correct_distribution_with_layout_v2(
     for swap in swaps[::-1]:
         C_new = C_new[swap_indices(num_qubits, swap)]
     # Convert columnvector of probabilities to bitstring distribution
-    for bitint, prob in dist.items():  # is this missing sth? Can I have new numbers?
-        dist[bitint] = C_new[bitint]
+    for bitint, prob in enumerate(C_new): 
+        dist[bitint] = prob
     return dist
 
 
 def correct_distribution_with_layout(
     dist: dict[int, float], M_in: np.ndarray, ref_layout: list[int], new_layout: list[int]
 ) -> dict[int, float]:
-    r"""Corrects a quasi-distribution of bitstrings based on a correlation matrix in statevector notation.
+    """Corrects a quasi-distribution of bitstrings based on a correlation matrix in statevector notation.
 
     Uses layout correction via M mapping.
 
     Args:
         dist: Quasi-distribution.
-        M: Correlation martix (not inverse).
+        M: Correlation matrix (not inverse).
         ref_layout: Reference layout of M measurement.
         new_layout: Layout of current to be corrected circuit measurement.
 
     Returns:
-        Quasi-distribution corrected by correlation matrix with corrected layout
+        Quasi-distribution corrected by correlation matrix with corrected layout.
     """
     # Find swaps that map new layout to reference layout
     # Layout indices need to be inverted due to qiskit saving layout indices q0->qN and distribtions qN->q0.
@@ -376,8 +376,8 @@ def correct_distribution_with_layout(
     # Apply M error mitigation matrix
     C_new = M_inv @ C
     # Convert columnvector of probabilities to bitstring distribution
-    for bitint, prob in dist.items():  # is this missing sth? Can I have new numbers?
-        dist[bitint] = C_new[bitint]
+    for bitint, prob in enumerate(C_new): 
+        dist[bitint] = prob
     return dist
 
 
@@ -385,12 +385,12 @@ def find_best_path(coupling_map: CouplingMap, start: int, target: int) -> list[i
     """Find the best path between two qubits using the coupling map.
 
     Args:
-        coupling_map (CouplingMap): The coupling map defining valid connections.
-        start (int): Starting qubit.
-        target (int): Target qubit.
+        coupling_map: The coupling map defining valid connections.
+        start: Starting qubit.
+        target: Target qubit.
 
     Returns:
-        list: List of qubits representing the path from start to target.
+        List of qubits representing the path from start to target.
     """
     # Convert the coupling map to a NetworkX graph
     graph = nx.Graph()
@@ -409,13 +409,10 @@ def add_permutation_gate(circuit: QuantumCircuit, permutation: list[int], coupli
     """Add a permutation gate to a circuit, adhering to a given coupling map.
 
     Args:
-        circuit (QuantumCircuit): The quantum circuit to modify.
-        permutation (list): A list defining the new positions of qubits.
+        circuit: The quantum circuit to modify.
+        permutation: A list defining the new positions of qubits.
                             E.g., [2, 0, 1] means qubit 0 goes to 2, 1 goes to 0, and 2 goes to 1.
-        coupling_map (CouplingMap): The coupling map that defines valid qubit connections.
-
-    Returns:
-        QuantumCircuit: The modified circuit with the permutation gate added.
+        coupling_map: The coupling map that defines valid qubit connections.
     """
     # Get the number of qubits
     num_qubits = len(permutation)
@@ -462,11 +459,11 @@ def layout_conserving_compose(
     """Composing an un-transpiled state circuit to the front of a transpiled Ansatz circuit.
 
     Args:
-        ansatz: Transpiled Ansatz circuit
-        state: Un-transpiled state circuit
-        pm: PassManager that produces Ansatz's initial layout indices
+        ansatz: Transpiled Ansatz circuit.
+        state: Un-transpiled state circuit.
+        pm: PassManager that produces Ansatz's initial layout indices.
         optimization: Boolean for optimizing composed circuit.
-            Note that optimization can lead to change in Ansatz's gates and CX count.
+            Note that optimization can lead to changes in Ansatz's gates and CX count.
             This can be problematic together with M_Ansatz0.
 
     Returns:
@@ -700,13 +697,13 @@ def get_determinant_superposition_reference_MAnsatz0(
     """Get superposition state for MAnsatz_0.
 
     Args:
-        det1: determinant string 1
-        det2: determinant string 2
-        num_orbs: Number of orbitals
-        mapper: Fermionic to qubit mapper
+        det1: determinant string 1.
+        det2: determinant string 2.
+        num_orbs: Number of spin orbitals.
+        mapper: Fermionic to qubit mapper.
 
     Returns:
-        Quantum circuit
+        Quantum circuit.
     """
     if not isinstance(mapper, JordanWignerMapper):
         raise TypeError("Only implemented for JordanWignerMapper. Got: {type(mapper)}")

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -463,12 +463,15 @@ def layout_conserving_compose(
     """
     print("\nLayout-conserving circuit composing requested.")
     print("Superposition state contains ", state.num_nonlocal_gates(), "non-local gates")
-    if ansatz.layout is not None: # or just use ISA_option 1
+    if ansatz.layout is not None:  # or just use ISA_option 1
         state_tmp = pm.run(state)
         nlg_state = state_tmp.num_nonlocal_gates()
         print("Transpiled superposition state contains ", nlg_state, "non-local gates")
 
-        if state_tmp.layout.initial_index_layout(filter_ancillas=True) != state_tmp.layout.final_index_layout():
+        if (
+            state_tmp.layout.initial_index_layout(filter_ancillas=True)
+            != state_tmp.layout.final_index_layout()
+        ):
             # Qiskit wants to change the layout? Not with me. Change it back!
             perm = PermutationGate(state_tmp.layout.routing_permutation())
             state_tmp.append(perm, list(range(ansatz.num_qubits)))
@@ -480,7 +483,11 @@ def layout_conserving_compose(
         if optimization:
             composed_opt = pm.optimization.run(composed)
             composed_opt._layout = ansatz.layout  # pylint: disable=protected-access
-            print("Optimization eliminated ", composed.num_nonlocal_gates() - composed_opt.num_nonlocal_gates(), "non-local gates")
+            print(
+                "Optimization eliminated ",
+                composed.num_nonlocal_gates() - composed_opt.num_nonlocal_gates(),
+                "non-local gates",
+            )
 
             return composed_opt
     else:
@@ -490,8 +497,12 @@ def layout_conserving_compose(
         composed = ansatz.compose(state_tmp, front=True)
         if optimization:
             composed_opt = pm.optimization.run(composed)
-            print("Optimization eliminated ", composed.num_nonlocal_gates() - composed_opt.num_nonlocal_gates(), "non-local gates")
-            
+            print(
+                "Optimization eliminated ",
+                composed.num_nonlocal_gates() - composed_opt.num_nonlocal_gates(),
+                "non-local gates",
+            )
+
             return composed_opt
 
     return composed

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -461,22 +461,39 @@ def layout_conserving_compose(
     Returns:
         Composed QuantumCircuit.
     """
-    state_tmp = pm.run(state)
-    if state_tmp.layout.initial_index_layout(filter_ancillas=True) != state_tmp.layout.final_index_layout():
-        # Qiskit wants to change the layout? Not with me. Change it back!
-        perm = PermutationGate(state_tmp.layout.routing_permutation())
-        state_tmp.append(perm, list(range(ansatz.num_qubits)))
-        state_tmp = pm.optimization.run(pm.translation.run(state_tmp))
+    print("\nLayout-conserving circuit composing requested.")
+    print("Superposition state contains ", state.num_nonlocal_gates(), "non-local gates")
+    if ansatz.layout is not None: # or just use ISA_option 1
+        state_tmp = pm.run(state)
+        nlg_state = state_tmp.num_nonlocal_gates()
+        print("Transpiled superposition state contains ", nlg_state, "non-local gates")
 
-    composed = ansatz.compose(state_tmp, front=True)
+        if state_tmp.layout.initial_index_layout(filter_ancillas=True) != state_tmp.layout.final_index_layout():
+            # Qiskit wants to change the layout? Not with me. Change it back!
+            perm = PermutationGate(state_tmp.layout.routing_permutation())
+            state_tmp.append(perm, list(range(ansatz.num_qubits)))
+            state_tmp = pm.optimization.run(pm.translation.run(state_tmp))
+            print("Layout correction added ", state_tmp.num_nonlocal_gates() - nlg_state, " non-local gates")
 
-    if optimization:
-        print(composed.count_ops())
-        composed_opt = pm.optimization.run(composed)
-        composed_opt._layout = ansatz.layout  # pylint: disable=protected-access
-        print(composed_opt.count_ops())
+        composed = ansatz.compose(state_tmp, front=True)
 
-        return composed_opt
+        if optimization:
+            composed_opt = pm.optimization.run(composed)
+            composed_opt._layout = ansatz.layout  # pylint: disable=protected-access
+            print("Optimization eliminated ", composed.num_nonlocal_gates() - composed_opt.num_nonlocal_gates(), "non-local gates")
+
+            return composed_opt
+    else:
+        state_tmp = pm.run(state)
+        nlg_state = state_tmp.num_nonlocal_gates()
+        print("Transpiled superposition state contains ", nlg_state, "non-local gates")
+        composed = ansatz.compose(state_tmp, front=True)
+        if optimization:
+            composed_opt = pm.optimization.run(composed)
+            print("Optimization eliminated ", composed.num_nonlocal_gates() - composed_opt.num_nonlocal_gates(), "non-local gates")
+            
+            return composed_opt
+
     return composed
 
 

--- a/slowquant/qiskit_interface/wavefunction.py
+++ b/slowquant/qiskit_interface/wavefunction.py
@@ -317,10 +317,7 @@ class WaveFunction:
         self.QI.total_shots_used = 0
         self.QI.total_paulis_evaluated = 0
 
-        # Reset circuit and initiate re-transpiling
-        ISA_old = self.QI.ISA
-        self._reconstruct_circuit()  # Reconstruct circuit but keeping parameters
-        self.QI.ISA = ISA_old  # Redo ISA including transpilation if requested
+        self.QI.ISA = self.QI.ISA  # Redo ISA including potential transpilation
         self.QI.shots = self.QI.shots  # Redo shots parameter check
 
         if verbose:
@@ -328,12 +325,9 @@ class WaveFunction:
 
     def _reconstruct_circuit(self) -> None:
         """Construct circuit again."""
-        # force ISA = False
-        self.QI._ISA = False  # pylint: disable=protected-access
         self.QI.construct_circuit(
             self.num_active_orbs, (self.num_active_elec // 2, self.num_active_elec // 2)
         )
-        self.QI._transpiled = False  # pylint: disable=protected-access
 
     @property
     def rdm1(self) -> np.ndarray:

--- a/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
@@ -588,6 +588,7 @@ class WaveFunctionSAUPS:
                 self.kappa_redundant[i] = 0
                 self._kappa_redundant_old[i] = 0
         self.thetas = res["x"][param_idx : num_theta + param_idx].tolist()
+        self._sa_energy = res["fun"]
         # Subspace diagonalization
         self._do_state_ci()
 

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -955,7 +955,7 @@ def test_H2_sampler_couplingmap() -> None:
 
     pm = generate_preset_pass_manager(3, backend=FakeTorino())
     QI.ISA = True
-    QI.pass_manager = pm
+    QI.pass_manager = (pm, FakeTorino())
 
     QI._reset_cliques()  # pylint: disable=protected-access
 

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -3,7 +3,6 @@ import numpy as np
 import pyscf
 from numpy.testing import assert_allclose
 from qiskit.primitives import Estimator, Sampler
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 from qiskit_aer.primitives import Sampler as SamplerAer
@@ -959,9 +958,7 @@ def test_H2_sampler_layout() -> None:
 
     qWF.run_vqe_2step("rotosolve", True)
 
-    pm = generate_preset_pass_manager(3, backend=FakeTorino())
-    QI.ISA = True
-    QI.pass_manager = (pm, FakeTorino())
+    QI.update_pass_manager({"backend": FakeTorino()})
 
     QI._reset_cliques()  # pylint: disable=protected-access
 
@@ -1019,7 +1016,7 @@ def test_state_average_layout() -> None:
         mapper,
         ansatz_options={"n_layers": 1},
         ISA=True,
-        pass_manager=(generate_preset_pass_manager(3, backend=FakeTorino()), FakeTorino()),
+        pass_manager_options={"backend": FakeTorino()},
     )
 
     QWF = WaveFunctionSA(
@@ -1098,7 +1095,7 @@ def test_state_average_M() -> None:
         ISA=True,
         do_M_mitigation=True,
         do_M_ansatz0=True,
-        pass_manager=(generate_preset_pass_manager(3, backend=FakeTorino()), FakeTorino()),
+        pass_manager_options={"backend": FakeTorino()},
     )
 
     QWF = WaveFunctionSA(

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -1198,14 +1198,12 @@ def test_state_average_Mplus() -> None:
     QI.shots = None
     QI.ISA = True
     QI.do_postselection = False
-
     QI.update_pass_manager({"backend": FakeTorino(), "seed_transpiler": 1234})
 
     QI.do_M_mitigation = False
     QI.do_M_ansatz0 = False
 
     QI._reset_cliques()
-
     assert abs(QWF._calc_energy_elec() + 9.60851106217584) < 10**-6  # type: ignore  # CSFs option 1
 
     QI.do_M_mitigation = True
@@ -1213,7 +1211,6 @@ def test_state_average_Mplus() -> None:
     QI.redo_M_mitigation()
 
     QI._reset_cliques()
-
     assert abs(QWF._calc_energy_elec() + 9.633426170009107) < 10**-6  # type: ignore  # CSFs option 4
 
     QI._reset_cliques()
@@ -1223,5 +1220,4 @@ def test_state_average_Mplus() -> None:
 
     QI.do_postselection = True
     QI._reset_cliques()
-
     assert abs(QWF._calc_energy_elec() + 9.636464216617595) < 10**-6  # type: ignore  # CSFs option 4

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -1122,4 +1122,6 @@ def test_state_average_M() -> None:
     )
     QWF.ansatz_parameters = WF.thetas
 
+    # This might fail if the noise model of FakeTorinto changes.
+    # But if it fails check if the Noise mode is the issue. Do NOT ignore this failing!
     assert abs(QWF._calc_energy_elec() == -1.3733093217175516) < 10**-6  # pylint: disable=protected-access

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -1,6 +1,4 @@
 # pylint: disable=too-many-lines
-from typing import cast
-
 import numpy as np
 import pyscf
 from numpy.testing import assert_allclose
@@ -1123,7 +1121,7 @@ def test_state_average_M() -> None:
 
     # This might fail if the noise model of FakeTorinto changes.
     # But if it fails check if the Noise mode is the issue. Do NOT ignore this failing!
-    assert abs(QWF._calc_energy_elec() == -1.3733093217175516) < 10**-6  # pylint: disable=protected-access
+    assert abs(QWF._calc_energy_elec() - -1.3733093217175516) < 10**-6  # pylint: disable=protected-access
 
 
 def test_state_average_Mplus() -> None:
@@ -1209,7 +1207,7 @@ def test_state_average_Mplus() -> None:
 
     QI._reset_cliques()  # pylint: disable=protected-access
     assert (
-        abs(cast(float, QWF._calc_energy_elec()) + 9.60851106217584)  # pylint: disable=protected-access
+        abs(QWF._calc_energy_elec() + 9.60851106217584)  # pylint: disable=protected-access # type: ignore
         < 10**-6
     )  # CSFs option 1
 
@@ -1219,14 +1217,14 @@ def test_state_average_Mplus() -> None:
 
     QI._reset_cliques()  # pylint: disable=protected-access
     assert (
-        abs(cast(float, QWF._calc_energy_elec()) + 9.633426170009107)  # pylint: disable=protected-access
+        abs(QWF._calc_energy_elec() + 9.633426170009107)  # pylint: disable=protected-access # type: ignore
         < 10**-6
     )  # CSFs option 4
 
     QI._reset_cliques()  # pylint: disable=protected-access
     assert (
         abs(
-            cast(float, QWF._calc_energy_elec(M_per_superpos=True))  # pylint: disable=protected-access
+            QWF._calc_energy_elec(M_per_superpos=True)  # pylint: disable=protected-access # type: ignore
             + 9.635276750167002
         )
         < 10**-6
@@ -1235,6 +1233,6 @@ def test_state_average_Mplus() -> None:
     QI.do_postselection = True
     QI._reset_cliques()  # pylint: disable=protected-access
     assert (
-        abs(cast(float, QWF._calc_energy_elec()) + 9.636464216617595)  # pylint: disable=protected-access
+        abs(QWF._calc_energy_elec() + 9.636464216617595)  # pylint: disable=protected-access # type: ignore
         < 10**-6
     )  # CSFs option 4

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -928,9 +928,9 @@ def test_custom() -> None:
     assert abs(QI.quantum_expectation_value(qc_H) - energy) < 10**-8
 
 
-def test_H2_sampler_couplingmap() -> None:
+def test_H2_sampler_layout() -> None:
     """
-    Test coupling map.
+    Test composing of circuits when complicated layout is applied.
     """
     # Define molecule
     atom = "H .0 .0 .0; H .0 .0 1.0"
@@ -969,9 +969,9 @@ def test_H2_sampler_couplingmap() -> None:
     )
 
 
-def test_state_average() -> None:
+def test_state_average_layout() -> None:
     """
-    Test RDM1 calculation with SA.
+    Test RDM1 calculation with SA in the presence of complicated layout.
     """
     SQobj = sq.SlowQuant()
     SQobj.set_molecule(


### PR DESCRIPTION
This PR allows to run superposition state expectation values on simulator and hardware. 
It includes some refactoring of the QuantumInterface and new functionalities:

* PassManager is handeled completely internally by passing a dictionary of pass manager options to the QI. This also changes how PassManager is updated in the workflow
* M_Ansatz0 allows custom circuits
* Slightly changed/optimised interplay of QI and WF in `change_primitive`
* New Pauli saving per determinant structure. This introduces the `QI.saver` dictionary
* M_Ansatz0+ error mitigation
* Layout checks before submission
* New util function `layout_conserving_compose` that combines a state and ansatz circuit enforcing the ansatz layout. Swap circuits can be inserted adhering to the quantum device's coupling map using [Networkx](https://github.com/networkx/networkx) for the shorted path search
* M (without gates) bit re-ordering function in case of change in routing
* Function `quantum_expectation_value_csfs` calculates expectation value of CSFs via superposition states. It allows for:
   * different options to handle superposition state circuits via `ISA_csfs_option` argument. Including a default option that chooses the best strategy depending on input parameters (M0 or not) that is based on numerical testing
   * Pauli saving based on determinant or superposition thereof
   * custom_parameters that automatically switches to no Pauli saving (for VQE)
   * automatic use of M0+ by specifying `M_per_superpos`
   * controlling the order of the pair-entangled determinant states via `reverse_csfs_order`
 * Minor additions to the SA WF, mainly `_calc_energy_elec` used for testing that calculates the SA energy
 * New tests, now also for error mitigation and layout problems