### PR TITLE
Refactoring QI and new saver capabilities

### DIFF
--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -24,7 +24,7 @@ from qiskit_nature.second_q.mappers.fermionic_mapper import FermionicMapper
 from qiskit_nature.second_q.operators import FermionicOp
 
 from slowquant.qiskit_interface.custom_ansatz import SDSfUCC, fUCC, tUPS
-from slowquant.qiskit_interface.util import (  # correct_distribution_with_layout,
+from slowquant.qiskit_interface.util import (
     Clique,
     MitigationFlags,
     correct_distribution,
@@ -74,7 +74,7 @@ class QuantumInterface:
             max_shots_per_run: Maximum number of shots allowed in a single run. Set to 100000 per IBM machines.
             do_M_mitigation: Do error mitigation via read-out correlation matrix.
             do_M_ansatz0: Use the ansatz with theta=0 when constructing the read-out correlation matrix.
-            do_M_ansatz0_plus: Creates M0 for each initia superposition state. Only used for SA-VQE.
+            do_M_ansatz0_plus: Creates M0 for each initial superposition state. Only used for SA-VQE.
             do_postselection: Use postselection to preserve number of particles in the computational basis.
         """
         if ansatz_options is None:
@@ -860,7 +860,6 @@ class QuantumInterface:
                             raise ValueError("Wrong ISA_csfs_option specified. Needs to be 1,2,3,4.")
                 else:
                     circuit = self.ansatz_circuit.compose(state, front=True)
-                # val_old = val  # debug
                 # Check if M per superposition circuit is requested
                 if self.mitigation_flags.do_M_ansatz0_plus:
                     state_corr = state.copy()
@@ -1637,4 +1636,4 @@ class QuantumInterface:
                 data += f"\n {key:<20} {value}"
             if isinstance(self._primitive, BaseSamplerV2) and hasattr(self._primitive.options, "twirling"):
                 data += f"\n {'Pauli twirling:':<20} {self._primitive.options.twirling.enable_gates}\n {'Dynamic decoupling:':<20} {self._primitive.options.dynamical_decoupling.enable}"
-        print(data + "\nMitigation flags:\n" + str(self.mitigation_flags.status_report()))
+        print(f"{data}\nMitigation flags:\n{self.mitigation_flags.status_report()}")

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -1076,13 +1076,13 @@ class QuantumInterface:
             # save raw results
             self.saver[det_int].update_distr(new_heads, distr)
 
-        if self.mitigation_flags.to_int() != 0:
+        if self.mitigation_flags.is_enabled():
             # figure out if mitigated result already exist.
             # if yes, do nothing and go to value calculation.
             # if not, generate new mitigated data based on raw data.
             # one could maybe also think of doing mitigation and its saving when new_heads is not empty.
             # that might make it faster!
-            head_mit, distr_raw = self.saver[det_int].get_empty_heads_distr(self.mitigation_flags.to_int())
+            head_mit, distr_raw = self.saver[det_int].get_empty_heads_distr(self.mitigation_flags)
 
             if len(head_mit) != 0:
                 if self.mitigation_flags.do_M_mitigation:  # apply error mitigation if requested
@@ -1092,13 +1092,13 @@ class QuantumInterface:
                     self._apply_postselection(distr_raw, head_mit)
 
                 # save mitigated results
-                self.saver[det_int].update_distr(head_mit, distr_raw, self.mitigation_flags.to_int())
+                self.saver[det_int].update_distr(head_mit, distr_raw, self.mitigation_flags)
 
         # Loop over all Pauli strings in observable and build final result with coefficients
         for pauli, coeff in zip(paulis_str, observables.coeffs):
             result = 0.0
             for key, value in (
-                self.saver[det_int].get_distr(pauli, self.mitigation_flags.to_int()).items()
+                self.saver[det_int].get_distr(pauli, self.mitigation_flags).items()
             ):  # build result from quasi-distribution
                 result += value * get_bitstring_sign(pauli, key)
             values += result * coeff
@@ -1247,7 +1247,7 @@ class QuantumInterface:
                 coeff = 1
             # Get distribution from cliques
             if do_cliques:
-                dist = self.saver[det_int].get_distr(pauli, self.mitigation_flags.to_int())
+                dist = self.saver[det_int].get_distr(pauli, self.mitigation_flags)
                 # Calculate p1: Probability of measuring one
                 p1 = 0.0
                 for key, value in dist.items():

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -57,7 +57,7 @@ class QuantumInterface:
         max_shots_per_run: int = 100000,
         do_M_mitigation: bool = False,
         do_M_ansatz0: bool = False,
-        do_postselection: bool = True,
+        do_postselection: bool = False,
     ) -> None:
         """Interface to Qiskit to use IBM quantum hardware or simulator.
 

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -243,6 +243,14 @@ class QuantumInterface:
             # Set parameter to HarteeFock
             self._parameters = [0.0] * self.circuit.num_parameters
 
+    def update_mitigation_flags(self, **kwargs) -> None:
+        """Update mitigation flags.
+
+        Args:
+            **kwargs: Keyword arguments to update mitigation flags.
+        """
+        self.mitigation_flags.update_flags(**kwargs)
+
     @property
     def ISA(self) -> bool:
         """Get ISA setting.

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -1075,6 +1075,7 @@ class QuantumInterface:
             # if yes, do nothing and go to value calculation.
             # if not, generate new mitigated data based on raw data.
             # one could maybe also think of doing mitigation and its saving when new_heads is not empty.
+            # that might make it faster!
             head_mit, distr_raw = self.saver[det_int].get_empty_heads_distr(self.mitigation_flags.to_int())
 
             if len(head_mit) != 0:
@@ -1104,6 +1105,7 @@ class QuantumInterface:
                                 raise ValueError("Detected layout conflict. Cannot do M mitigation.")
                     else:
                         # get custom M
+                        # that might be wrong to do ? think about it!
                         Minv = self._make_Minv(shots=self._M_shots, custom_ansatz=circuit_M)
                         # custom M -> no layout check needed / possible
                         for i, dist in enumerate(distr_raw):

--- a/slowquant/qiskit_interface/sa_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_wavefunction.py
@@ -319,7 +319,7 @@ class WaveFunctionSA:
             print("WARNING: Using SamplerV2 is an experimental feature.")
         self.QI._primitive = primitive  # pylint: disable=protected-access
         if verbose:
-            if self.QI.do_M_ansatz0:
+            if self.QI.mitigation_flags.do_M_ansatz0:
                 print("Reset RDMs, energies, QI metrics, and correlation matrix.")
             else:
                 print("Reset RDMs, energies, and QI metrics.")

--- a/slowquant/qiskit_interface/sa_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_wavefunction.py
@@ -826,14 +826,11 @@ class WaveFunctionSA:
             osc_strs[idx] = 2 / 3 * excitation_energy * (td_x**2 + td_y**2 + td_z**2)
         return osc_strs
 
-    def _calc_energy_elec(
-        self, ISA_csfs_option: int = 0, M_per_superpos: bool = False, rep: int = 1
-    ) -> list[float] | float:
+    def _calc_energy_elec(self, ISA_csfs_option: int = 0, rep: int = 1) -> list[float] | float:
         """Run electronic energy simulation.
 
         Args:
             ISA_csfs_option: Option for how to deal with superposition state circuits.
-            M_per_superpos: Switch on M0 per superposition state.
             rep: Repeat energy calculation for statistics.
 
         Returns:
@@ -849,7 +846,6 @@ class WaveFunctionSA:
                     H,
                     (coeffs, csf),
                     ISA_csfs_option=ISA_csfs_option,
-                    M_per_superpos=M_per_superpos,
                 )
 
             return energy / self.num_states
@@ -862,7 +858,6 @@ class WaveFunctionSA:
                     H,
                     (coeffs, csf),
                     ISA_csfs_option=ISA_csfs_option,
-                    M_per_superpos=M_per_superpos,
                 )
             energy = energy / self.num_states
             energies.append(energy)

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -217,6 +217,12 @@ class MitigationFlags:
             self.do_M_ansatz0 = True
         print("You selected the following mitigation flags:\n" + self.status_report())
 
+    def all_to_false(self) -> None:
+        """Set all mitigation flags to False."""
+        for flag in self.flag_order():
+            setattr(self, flag, False)
+        print("All mitigation flags set to False.")
+
     def to_int(self) -> int:
         """Convert mitigation flags to an integer representation.
 
@@ -329,9 +335,10 @@ class Clique:
     #. 10.1109/TQE.2020.3035814, Sec. IV. A, IV. B, and VIII.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, csfs_option: int = 1) -> None:
         """Initialize clique class."""
         self.cliques: list[CliqueHead] = []
+        self.csfs_option = csfs_option
 
     def add_paulis(self, paulis: list[str]) -> list[str]:
         """Add list of Pauli strings to cliques and return clique heads to be simulated.
@@ -482,6 +489,14 @@ class Clique:
         print("Clique heads and their distributions:")
         for clique_head in self.cliques:
             print(f"Head: {clique_head.head}, Distribution: {clique_head.distr.data}")
+
+    def print_clique_heads(self) -> None:
+        """Print all clique heads."""
+        print("Clique heads:")
+        heads = []
+        for clique_head in self.cliques:
+            heads.append(clique_head.head)
+        print(heads)
 
 
 def fit_in_clique(pauli: str, head: str) -> tuple[bool, str]:

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -200,11 +200,6 @@ class MitigationFlags:
         for flag in flag_dict.items():
             if not isinstance(flag[1], bool):
                 raise TypeError(f"{flag[0]} must be a boolean")
-        if self.do_M_ansatz0 is True:
-            self.do_M_mitigation = True
-        if self.do_M_ansatz0_plus is True:
-            self.do_M_mitigation = True
-            self.do_M_ansatz0 = True
 
     def update_flags(self, **kwargs) -> None:
         """Update mitigation flags with provided keyword arguments.
@@ -215,6 +210,11 @@ class MitigationFlags:
         self._validate_flags(kwargs)
         for flag, value in kwargs.items():
             setattr(self, flag, value)
+        if self.do_M_ansatz0 is True:
+            self.do_M_mitigation = True
+        if self.do_M_ansatz0_plus is True:
+            self.do_M_mitigation = True
+            self.do_M_ansatz0 = True
         print("You selected the following mitigation flags:\n" + self.status_report())
 
     def to_int(self) -> int:
@@ -474,7 +474,7 @@ class Clique:
         for clique_head in self.cliques:
             if clique_head.distr.empty(mitigation_int):
                 heads.append(clique_head.head)
-                distr.append(clique_head.distr.data[0])  # raw data
+                distr.append(clique_head.distr.data[0].copy())  # raw data
         return heads, distr
 
     def print_cliques(self) -> None:

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -324,7 +324,6 @@ class CliqueHead:
             head: Clique head.
             distr: Sample state distribution.
         """
-        # Could that not be a dictionary?
         self.head = head
         self.distr = CliqueSaver()
 

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -301,6 +301,7 @@ class CliqueHead:
             head: Clique head.
             distr: Sample state distribution.
         """
+        # Could that not be a dictionary?
         self.head = head
         self.distr = CliqueSaver()
 
@@ -400,6 +401,64 @@ class Clique:
                     )
                 return clique_head.distr.get_distr(mitigation_int)
         raise ValueError(f"Could not find matching clique for Pauli, {pauli}")
+
+    def get_empty_heads(self, mitigation_int) -> list[str]:
+        """Return all heads that do not have any data for a specific mitigation int.
+
+        Args:
+            mitigation_int: Mitigation integer, default is 0.
+
+        Returns:
+            List of heads that have no data for the given mitigation integer.
+        """
+        empties = []
+        for clique_head in self.cliques:
+            if clique_head.distr.empty(mitigation_int):
+                empties.append(clique_head.head)
+        return empties
+
+    def get_distr_heads(self, heads: list[str], mitigation_int: int = 0) -> list[dict[int, float]]:
+        """Return the distribution data for a list of heads and for a given mitigation int (default 0).
+
+        This function looks only for the specific heads given, not trying to find pauli strings in commuting heads.
+        The latter would be the function get_distr.
+
+        Args:
+            heads: List of clique heads.
+            mitigation_int: Mitigation integer, default is 0.
+
+        Returns:
+            List of distributions for the given heads and mitigation integer.
+        """
+        distr = []
+        # This needs looping many times over all cliques.
+        # To avoid this one would need to re-write the whole clique structure into dictionaries.
+        # But this might make the other clique operations slower.
+        for head in heads:
+            for clique_heads in self.cliques:
+                if clique_heads.head == head:
+                    distr.append(clique_heads.distr.data[mitigation_int])
+                    break
+
+        return distr
+
+    def get_empty_heads_distr(self, mitigation_int) -> tuple[list[str], list[dict[int, float]]]:
+        """Return all heads that have empty data for a given mitigation_int plus return the corresponding raw data.
+
+        Args:
+            mitigation_int: Mitigation integer, default is 0.
+
+        Returns:
+            Tuple of lists: List of heads that have no data for the given mitigation integer,
+            and list of corresponding raw data distributions.
+        """
+        heads = []
+        distr = []
+        for clique_head in self.cliques:
+            if clique_head.distr.empty(mitigation_int):
+                heads.append(clique_head.head)
+                distr.append(clique_head.distr.data[0])  # raw data
+        return heads, distr
 
 
 # class Savers:

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -164,14 +164,23 @@ class MitigationFlags:
         Args:
             **kwargs: Flags to be set. If a flag is not provided, it defaults to False.
         """
-        unknown_flags = set(kwargs) - set(self.FLAG_ORDER)
-        print(unknown_flags)
-        if unknown_flags:
-            raise ValueError(f"Unknown flag(s): {', '.join(unknown_flags)}")
+        self._validate_flags(kwargs)
 
         for flag in self.FLAG_ORDER:
             setattr(self, flag, kwargs.get(flag, False))
+    
+    def _validate_flags(self, flag_dict):
+        """Validate the provided flags against the defined FLAG_ORDER."""
+        unknown_flags = set(flag_dict) - set(self.FLAG_ORDER)
+        if unknown_flags:
+            raise ValueError(f"Unknown flag(s): {', '.join(unknown_flags)}")
 
+    def update_flags(self, **kwargs):
+        """Update mitigation flags with provided keyword arguments."""
+        self._validate_flags(kwargs)
+        for flag, value in kwargs.items():
+            setattr(self, flag, value)
+    
     def to_int(self) -> int:
         """Convert mitigation flags to an integer representation."""
         result = 0

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -153,19 +153,28 @@ class MitigationFlags:
     """Class to handle mitigation flags."""
 
     def __init__(
-        self, do_M_mitigation: bool = False, do_M_ansatz0: bool = False, do_postselection: bool = False
+        self,
+        do_M_mitigation: bool = False,
+        do_M_ansatz0: bool = False,
+        do_M_ansatz0_plus: bool = False,
+        do_postselection: bool = False,
     ):
         """Initialize mitigation flags.
 
         Args:
             do_M_mitigation: Whether to perform error mitigation.
             do_M_ansatz0: Whether to perform M0 mitigation.
+            do_M_ansatz0_plus: Whether to perform M0 mitigation for each initial superposition state.
             do_postselection: Whether to perform post-selection.
         """
         if do_M_ansatz0 is True:
             do_M_mitigation = True
+        if do_M_ansatz0_plus is True:
+            do_M_mitigation = True
+            do_M_ansatz0 = True
         self.do_M_mitigation = do_M_mitigation
         self.do_M_ansatz0 = do_M_ansatz0
+        self.do_M_ansatz0_plus = do_M_ansatz0_plus
         self.do_postselection = do_postselection
 
     def flag_order(self) -> list[str]:
@@ -174,7 +183,7 @@ class MitigationFlags:
         Returns:
             List of flag names in the order they should be processed.
         """
-        return ["do_M_mitigation", "do_M_ansatz0", "do_postselection"]
+        return ["do_M_mitigation", "do_M_ansatz0", "do_M_ansatz0_plus", "do_postselection"]
 
     def _validate_flags(self, flag_dict):
         """Validate the provided flags against the defined flag_order.

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import networkx as nx
 import numpy as np
 from qiskit import QuantumCircuit
@@ -253,7 +254,14 @@ class CliqueSaver:
         self.data = {0: {}}  # reset to empty raw results saver
 
     def empty(self, mitigation_int: int = 0) -> bool:
-        """Check if saver is empty."""
+        """Check if saver is empty.
+
+        Args:
+            mitigation_int: Mitigation integer, default is 0.
+
+        Returns:
+            True if empty, False otherwise.
+        """
         if mitigation_int not in self.data:
             return True  # it is empty if it does not exist.
         if self.data[mitigation_int]:
@@ -264,12 +272,24 @@ class CliqueSaver:
                 raise ValueError("Empty data not consistent accross mitigation saver.")
         return True  # empty
 
-    def add_distr(self, distr: dict[int, float], mitigation_int: int = 0):
-        """Add distribution to saver."""
+    def add_distr(self, distr: dict[int, float], mitigation_int: int = 0) -> None:
+        """Add distribution to saver.
+
+        Args:
+            distr: Distribution to be added.
+            mitigation_int: Mitigation integer, default is 0.
+        """
         self.data[mitigation_int] = distr
 
     def get_distr(self, mitigation_int: int = 0) -> dict[int, float]:
-        """Return distribution."""
+        """Return distribution.
+
+        Args:
+            mitigation_int: Mitigation integer, default is 0.
+
+        Returns:
+            Distribution for the given mitigation integer.
+        """
         return self.data[mitigation_int]
 
 

--- a/slowquant/qiskit_interface/wavefunction.py
+++ b/slowquant/qiskit_interface/wavefunction.py
@@ -304,7 +304,7 @@ class WaveFunction:
             print("WARNING: Using SamplerV2 is an experimental feature.")
         self.QI._primitive = primitive  # pylint: disable=protected-access
         if verbose:
-            if self.QI.do_M_ansatz0:
+            if self.QI.mitigation_flags.do_M_ansatz0:
                 print("Reset RDMs, energies, QI metrics, and correlation matrix.")
             else:
                 print("Reset RDMs, energies, and QI metrics.")

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -1197,17 +1197,15 @@ def test_state_average_Mplus() -> None:
 
     QI.shots = None
     QI.ISA = True
-    QI.do_postselection = False
+    QI.update_mitigation_flags(do_postselection = False)
     QI.update_pass_manager({"backend": FakeTorino(), "seed_transpiler": 1234})
 
-    QI.do_M_mitigation = False
-    QI.do_M_ansatz0 = False
+    QI.update_mitigation_flags(do_M_mitigation = False, do_M_ansatz0 = False)
 
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.60851106217584) < 10**-6  # type: ignore  # CSFs option 1
 
-    QI.do_M_mitigation = True
-    QI.do_M_ansatz0 = True
+    QI.update_mitigation_flags(do_M_mitigation = True, do_M_ansatz0 = True)
     QI.redo_M_mitigation()
 
     QI._reset_cliques()
@@ -1218,6 +1216,6 @@ def test_state_average_Mplus() -> None:
         abs(QWF._calc_energy_elec(M_per_superpos=True) + 9.635276750167002) < 10**-6  # type: ignore
     )  # CSFs option 1
 
-    QI.do_postselection = True
+    QI.update_mitigation_flags(do_postselection = True)
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.636464216617595) < 10**-6  # type: ignore  # CSFs option 4

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -1094,6 +1094,7 @@ def test_state_average_M() -> None:
         ISA=True,
         do_M_mitigation=True,
         do_M_ansatz0=True,
+        do_postselection=True,
         pass_manager_options={"backend": FakeTorino(), "seed_transpiler": 1234},
     )
 
@@ -1189,7 +1190,7 @@ def test_state_average_Mplus() -> None:
     )
     QWF.ansatz_parameters = WF.thetas
 
-    assert abs(WF._sa_energy - QWF._calc_energy_elec()) < 10**-6
+    assert abs(WF._sa_energy - QWF._calc_energy_elec()) < 10**-6  # type: ignore
 
     noise_model = NoiseModel.from_backend(FakeTorino())
     sampler = SamplerAer(backend_options={"noise_model": noise_model})
@@ -1197,15 +1198,15 @@ def test_state_average_Mplus() -> None:
 
     QI.shots = None
     QI.ISA = True
-    QI.update_mitigation_flags(do_postselection = False)
+    QI.update_mitigation_flags(do_postselection=False)
     QI.update_pass_manager({"backend": FakeTorino(), "seed_transpiler": 1234})
 
-    QI.update_mitigation_flags(do_M_mitigation = False, do_M_ansatz0 = False)
+    QI.update_mitigation_flags(do_M_mitigation=False, do_M_ansatz0=False)
 
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.60851106217584) < 10**-6  # type: ignore  # CSFs option 1
 
-    QI.update_mitigation_flags(do_M_mitigation = True, do_M_ansatz0 = True)
+    QI.update_mitigation_flags(do_M_mitigation=True, do_M_ansatz0=True)
     QI.redo_M_mitigation()
 
     QI._reset_cliques()
@@ -1216,6 +1217,6 @@ def test_state_average_Mplus() -> None:
         abs(QWF._calc_energy_elec(M_per_superpos=True) + 9.635276750167002) < 10**-6  # type: ignore
     )  # CSFs option 1
 
-    QI.update_mitigation_flags(do_postselection = True)
+    QI.update_mitigation_flags(do_postselection=True)
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.636464216617595) < 10**-6  # type: ignore  # CSFs option 4

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -1198,24 +1198,25 @@ def test_state_average_Mplus() -> None:
 
     QI.shots = None
     QI.ISA = True
-    QI.update_mitigation_flags(do_postselection=False)
     QI.update_pass_manager({"backend": FakeTorino(), "seed_transpiler": 1234})
 
-    QI.update_mitigation_flags(do_M_mitigation=False, do_M_ansatz0=False)
-
+    # No EM
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.60851106217584) < 10**-6  # type: ignore  # CSFs option 1
 
+    # EM with M_Ansatz0
     QI.update_mitigation_flags(do_M_mitigation=True, do_M_ansatz0=True)
-    QI.redo_M_mitigation()
+    # QI.redo_M_mitigation()
 
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.633426170009107) < 10**-6  # type: ignore  # CSFs option 4
 
+    # EM with M_Ansatz0+
     QI._reset_cliques()
     QI.update_mitigation_flags(do_M_ansatz0_plus=True)
     assert abs(QWF._calc_energy_elec() + 9.635276750167002) < 10**-6  # type: ignore  # CSFs option 1
 
+    # EM with M_Ansatz0 and postselection
     QI.update_mitigation_flags(do_postselection=True, do_M_ansatz0_plus=False)
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.636464216617595) < 10**-6  # type: ignore  # CSFs option 4

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -1213,10 +1213,9 @@ def test_state_average_Mplus() -> None:
     assert abs(QWF._calc_energy_elec() + 9.633426170009107) < 10**-6  # type: ignore  # CSFs option 4
 
     QI._reset_cliques()
-    assert (
-        abs(QWF._calc_energy_elec(M_per_superpos=True) + 9.635276750167002) < 10**-6  # type: ignore
-    )  # CSFs option 1
+    QI.update_mitigation_flags(do_M_ansatz0_plus=True)
+    assert abs(QWF._calc_energy_elec() + 9.635276750167002) < 10**-6  # type: ignore  # CSFs option 1
 
-    QI.update_mitigation_flags(do_postselection=True)
+    QI.update_mitigation_flags(do_postselection=True, do_M_ansatz0_plus=False)
     QI._reset_cliques()
     assert abs(QWF._calc_energy_elec() + 9.636464216617595) < 10**-6  # type: ignore  # CSFs option 4


### PR DESCRIPTION
Clean-up of Quantum Interface and new features: 

- applying error mitigation and post-selection is its own internal function now. Makes code cleaner and removes redundant lines.
- error mitigation options are handled externally using the `MitigationFlags` class in util.py. This allows us to asign a binary (or integer) to each unique combination of error mitigation and postselection. 
- The `Clique` class has been re-written to save raw and error mitigated results simultaneously. The error mitigated results have above mentioned integer as unique identifier. 
- More tests to also check no_save implementation and variance calculations
- The saver can be saved and loaded using pickl. This allows to save raw and mitigated results. It also gives the option to mitigate previously calculated raw results with new mitigation strategies. 

The saver structure:
- Within QI `self.saver` is a dictionary of determinant integer and a Clique object, `dict[int, Clique]`. The determinant integer identifies the determinant that was used in the calculation. E.g. Hartere-Fock (1..10..0) for all non-SA calculations or excited references and superposition of determinants for SA. Superposition states are just integer of the two binary representation of the underlying determinants put together. 
- Each Clique consists of a list of `CliqueHead`s and a `csfs_option` integer. The former saves all clique head Pauli strings and their corresponding distributions (see below), while the latter classifies how the distributions within this Clique object have been obtained. Default is 1, meaning the standard combination of the determinant and the Ansatz, while the other options refer to manipulations that had to be done on the circuit for SA simulations. This is important to differentiate as raw results obtained using `csfs_option = 1` should not be used to calculate mitigated results that need `csfs_option = 4` as they have used different Ansatz. This is the case in SA-VQE calculations that use M0. 
- A `CliqueHead` consist of the Pauli string (`head`) and a `CliqueSaver` object. The latter handles the distributions associated to `head`.
- The `CliqueSaver`  saves distributions associated with a given `MitigationFlags` integer. This means it saves distributions and associates them with how they were obtained, which is classified by the `MitigationFlags` integer. 
- Currently, the mitigation flags are: `["do_M_mitigation", "do_M_ansatz0", "do_M_ansatz0_plus", "do_postselection"]` and each combinations thereof has a unique identifier. 

How the saver works in action:
- If an expectation value is calculated using `_sampler_quantum_expectation_value`, the raw results are calculated on (emulated) hardware if no raw results exist for the requested pauli strings and for `mitigation_int = 0`. These are then stored for each `CliqueHead` in its `CliqueSaver` assiciated with the raw result mitigation integer. 
- If any error mitigation or postselection is requested, it is checked if distributions exist for the given Pauli strings (or rather their heads) and the chosen mitigation combination (characterized by a unique mitigation integer). If they exist, they are loaded and the expectation value is calculated. If they do not exist, the corresponding raw results (`mitigation_int = 0`) are loaded and the mitigations are applied. Then, the mitigated results are added to each CliqueHead's CliqueSaver object. 
- If the `csfs_option` requested at the level of `_sampler_quantum_expectation_value` does not coincide with the `csfs_option` of the saved results, the raw results are re-run to obtain the correct raw results. 

How to run things now:
- The only code difference is that you change error mitigation and postselection using: `QI.update_mitigation_flags(do_postselection=True)`
You just pass whatever change you want to perform to this function. The allowed flags are:  `["do_M_mitigation", "do_M_ansatz0", "do_M_ansatz0_plus", "do_postselection"]`
- You save and load data using:
`QI.load_paulis_from_file(filename)` and `QI.save_paulis_to_file(filename)`
- If you do not do SA-VQE, i.e. single state calculations, just run whatever error mitigation combo you want first. If you then change the flags (see above), it will autmatically use te raw results you already have to apply different mitigation combinations. 
- If you run SA-VQE, you have the "problem" of the `csfs_option` that can alter your circuit and thus raw results might not match your mitigation integer. It will not lead to wrong results as this will be caught by the code (see above). But the most efficient way to approach this is to run it first with the error mitigation you want (e.g. M0) to ensure it saves raw results with the correct `csfs_option` flag. Note that if you would now run M0+, it would re-run the raw results as M0+ uses `csfs_option=1`, meaning it does not do any circuit manipulation as it creates a new M0 matrix for each determinant. 

Do not ignore the print statements they have useful information and can avoid mistakes. And if in doubt, ask me!