### PR TITLE
Speed up of classical UPS implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.17.0
     hooks:
       - id: mypy
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.12.4
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: mypy
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.4
+    rev: v0.12.5
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/slowquant/qiskit_interface/linear_response/lr_baseclass.py
+++ b/slowquant/qiskit_interface/linear_response/lr_baseclass.py
@@ -60,40 +60,6 @@ class quantumLRBaseClass:
 
         self.orbs = [self.wf.num_inactive_orbs, self.wf.num_active_orbs, self.wf.num_virtual_orbs]
 
-    def get_operator_info(self) -> None:
-        """Information about operators."""
-        # q operators
-        print(f"{'Annihilation'.center(12)} | {'Creation'.center(12)} | {'Coefficient'.center(12)}\n")
-        if self.num_q > 0:
-            print("Orbital rotation operators:")
-            for nr, op in enumerate(self.q_ops):
-                annihilation, creation, coefficients = op.get_info()
-                print("q" + str(nr) + ":")
-                for a, c, coeff in zip(annihilation, creation, coefficients):
-                    if a[0] in self.wf.active_spin_idx:
-                        exc_type = "active -> virtual"
-                    elif c[0] in self.wf.active_spin_idx:
-                        exc_type = "inactive -> active"
-                    else:
-                        exc_type = "inactive -> virtual"
-                    print(
-                        str(a).center(12)
-                        + " | "
-                        + str(c).center(12)
-                        + " | "
-                        + f"{coeff:.3f}".center(12)
-                        + " | "
-                        + exc_type
-                    )
-
-        if self.num_G > 0:
-            print("Active-space excitation operators:")
-            for nr, op in enumerate(self.G_ops):
-                annihilation, creation, coefficients = op.get_info()
-                print("G" + str(nr) + ":")
-                for a, c, coeff in zip(annihilation, creation, coefficients):
-                    print(str(a).center(12) + " | " + str(c).center(12) + " | " + f"{coeff:.3f}".center(12))
-
     def run(self) -> None:
         """Run linear response."""
         raise NotImplementedError

--- a/slowquant/unitary_coupled_cluster/ci_spaces.py
+++ b/slowquant/unitary_coupled_cluster/ci_spaces.py
@@ -2,7 +2,7 @@ from collections.abc import Generator
 
 import numpy as np
 from sympy.utilities.iterables import multiset_permutations
-
+import numba as nb
 
 class CI_Info:
     __slots__ = (
@@ -43,7 +43,11 @@ class CI_Info:
         self.num_active_elec_alpha = num_active_elec_alpha
         self.num_active_elec_beta = num_active_elec_beta
         self.idx2det = idx2det
-        self.det2idx = det2idx
+        nb_dict = nb.typed.Dict.empty(key_type=nb.int64, value_type=nb.int64)
+        # Populate it
+        for k, v in det2idx.items():
+            nb_dict[k] = v
+        self.det2idx = nb_dict
         self.space_extension_offset = 0
 
 

--- a/slowquant/unitary_coupled_cluster/ci_spaces.py
+++ b/slowquant/unitary_coupled_cluster/ci_spaces.py
@@ -1,8 +1,9 @@
 from collections.abc import Generator
 
+import numba as nb
 import numpy as np
 from sympy.utilities.iterables import multiset_permutations
-import numba as nb
+
 
 class CI_Info:
     __slots__ = (

--- a/slowquant/unitary_coupled_cluster/ci_spaces.py
+++ b/slowquant/unitary_coupled_cluster/ci_spaces.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 
 import numba as nb
+import numba.typed as nbt
 import numpy as np
 from sympy.utilities.iterables import multiset_permutations
 
@@ -44,8 +45,8 @@ class CI_Info:
         self.num_active_elec_alpha = num_active_elec_alpha
         self.num_active_elec_beta = num_active_elec_beta
         self.idx2det = idx2det
-        nb_dict = nb.typed.Dict.empty(key_type=nb.int64, value_type=nb.int64)
-        # Populate it
+        # Unfortunately, Numba needs a little bit of typing help.
+        nb_dict = nbt.Dict.empty(key_type=nb.int64, value_type=nb.int64)
         for k, v in det2idx.items():
             nb_dict[k] = v
         self.det2idx = nb_dict

--- a/slowquant/unitary_coupled_cluster/fermionic_operator.py
+++ b/slowquant/unitary_coupled_cluster/fermionic_operator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import re
 
 
 def a_op(spinless_idx: int, spin: str, dagger: bool) -> tuple[int, bool]:
@@ -212,6 +211,26 @@ class FermionicOperator:
                 operators[string_key] = fermistring.operators[string_key]
                 factors[string_key] = fermistring.factors[string_key]
         return FermionicOperator(operators, factors)
+
+    def __iadd__(self, fermistring: FermionicOperator) -> FermionicOperator:
+        """Inplace addition of two fermionic operators.
+
+        Args:
+            fermistring: Fermionic operator.
+
+        Returns:
+            Updated fermionic operator.
+        """
+        for string_key in fermistring.operators.keys():
+            if string_key in self.operators.keys():
+                self.factors[string_key] += fermistring.factors[string_key]
+                if abs(self.factors[string_key]) < 10**-14:
+                    del self.factors[string_key]
+                    del self.operators[string_key]
+            else:
+                self.operators[string_key] = fermistring.operators[string_key]
+                self.factors[string_key] = fermistring.factors[string_key]
+        return self
 
     def __sub__(self, fermistring: FermionicOperator) -> FermionicOperator:
         """Subtraction of two fermionic operators.
@@ -448,19 +467,3 @@ class FermionicOperator:
                 factors[new_key] = fac * self.factors[key_string]
                 operators[new_key] = active_op
         return FermionicOperator(operators, factors)
-
-    def get_info(self) -> tuple[list[list[int]], list[list[int]], list[float]]:
-        """Return operator excitation in ordered strings with coefficient."""
-        excitations = list(self.factors.keys())
-        coefficients = list(self.factors.values())
-        creation = []
-        annihilation = []
-        for op_string in excitations:
-            numbers = re.findall(r"\d+", op_string)
-            numbers = [int(num) for num in numbers]
-            midpoint = len(numbers) // 2
-            c = numbers[:midpoint]
-            a = numbers[midpoint:]
-            creation.append(c)
-            annihilation.append(a)
-        return annihilation, creation, coefficients

--- a/slowquant/unitary_coupled_cluster/fermionic_operator.py
+++ b/slowquant/unitary_coupled_cluster/fermionic_operator.py
@@ -4,10 +4,7 @@ import copy
 import re
 
 
-class a_op:
-    __slots__ = ("dagger", "idx", "spin", "spinless_idx")
-
-    def __init__(self, spinless_idx: int, spin: str, dagger: bool) -> None:
+def a_op(spinless_idx: int, spin: str, dagger: bool) -> tuple[int, bool]:
         """Initialize fermionic annihilation operator.
 
         Args:
@@ -17,15 +14,13 @@ class a_op:
         """
         if spin not in ("alpha", "beta"):
             raise ValueError(f'spin must be "alpha" or "beta" got {spin}')
-        self.spinless_idx = spinless_idx
-        self.idx = 2 * self.spinless_idx
-        self.dagger = dagger
-        self.spin = spin
-        if self.spin == "beta":
-            self.idx += 1
+        idx = 2 * spinless_idx
+        if spin == "beta":
+            idx += 1
+        return (idx, dagger)
 
 
-def a_op_spin(spin_idx: int, dagger: bool) -> a_op:
+def a_op_spin(spin_idx: int, dagger: bool) -> tuple[int, bool]:
     """Get fermionic annihilation operator.
 
     Args:
@@ -35,9 +30,7 @@ def a_op_spin(spin_idx: int, dagger: bool) -> a_op:
     Returns:
         Annihilation operator.
     """
-    if spin_idx % 2 == 0:
-        return a_op(spin_idx // 2, "alpha", dagger)
-    return a_op(spin_idx // 2, "beta", dagger)
+    return (spin_idx, dagger)
 
 
 def operator_string_to_key(operator_string: list[tuple[int, bool]]) -> str:
@@ -135,7 +128,7 @@ def do_extended_normal_ordering(
                         next_operator[i], next_operator[j] = next_operator[j], next_operator[i]
                         factor *= -1
                         changed = True
-                elif a.dagger and not b.dagger:
+                elif a[1] and not b[1]:
                     pass
                 elif a[0] == b[0]:
                     is_zero = True

--- a/slowquant/unitary_coupled_cluster/fermionic_operator.py
+++ b/slowquant/unitary_coupled_cluster/fermionic_operator.py
@@ -5,19 +5,19 @@ import re
 
 
 def a_op(spinless_idx: int, spin: str, dagger: bool) -> tuple[int, bool]:
-        """Initialize fermionic annihilation operator.
+    """Initialize fermionic annihilation operator.
 
-        Args:
-            spinless_idx: Spatial orbital index.
-            spin: Alpha or beta spin.
-            dagger: If creation operator.
-        """
-        if spin not in ("alpha", "beta"):
-            raise ValueError(f'spin must be "alpha" or "beta" got {spin}')
-        idx = 2 * spinless_idx
-        if spin == "beta":
-            idx += 1
-        return (idx, dagger)
+    Args:
+        spinless_idx: Spatial orbital index.
+        spin: Alpha or beta spin.
+        dagger: If creation operator.
+    """
+    if spin not in ("alpha", "beta"):
+        raise ValueError(f'spin must be "alpha" or "beta" got {spin}')
+    idx = 2 * spinless_idx
+    if spin == "beta":
+        idx += 1
+    return (idx, dagger)
 
 
 def a_op_spin(spin_idx: int, dagger: bool) -> tuple[int, bool]:
@@ -158,7 +158,9 @@ class FermionicOperator:
     __slots__ = ("factors", "operators")
 
     def __init__(
-        self, annihilation_operator: dict[str, list[tuple[int, bool]]] | tuple[int, bool], factor: dict[str, float] | float
+        self,
+        annihilation_operator: dict[str, list[tuple[int, bool]]] | tuple[int, bool],
+        factor: dict[str, float] | float,
     ) -> None:
         """Initialize fermionic operator class.
 
@@ -412,13 +414,13 @@ class FermionicOperator:
                     if anni[0] in inactive_idx:
                         inactive_dagger.append(anni[0])
                     elif anni[0] in active_idx:
-                        active_dagger.append((anni[0] - 2*num_inactive_orbs, anni[1]))
+                        active_dagger.append((anni[0] - 2 * num_inactive_orbs, anni[1]))
                     elif anni[0] in virtual_idx:
                         virtual_dagger.append(anni[0])
                 elif anni[0] in inactive_idx:
                     inactive.append(anni[0])
                 elif anni[0] in active_idx:
-                    active.append((anni[0] - 2*num_inactive_orbs, anni[1]))
+                    active.append((anni[0] - 2 * num_inactive_orbs, anni[1]))
                 elif anni[0] in virtual_idx:
                     virtual.append(anni[0])
             # Any virtual indices will make the operator evaluate to zero.

--- a/slowquant/unitary_coupled_cluster/fermionic_operator.py
+++ b/slowquant/unitary_coupled_cluster/fermionic_operator.py
@@ -32,7 +32,7 @@ def a_op_spin(spin_idx: int, dagger: bool) -> tuple[int, bool]:
     return (spin_idx, dagger)
 
 
-def operator_string_to_key(operator_string: list[tuple[int, bool]]) -> str:
+def operator_string_to_key(operator_string: list[tuple[int, bool]]) -> tuple[tuple[int, bool], ...]:
     """Make key string to index a fermionic operator in a dict structure.
 
     Args:
@@ -41,13 +41,7 @@ def operator_string_to_key(operator_string: list[tuple[int, bool]]) -> str:
     Returns:
         Dictionary key.
     """
-    string_key = ""
-    for a in operator_string:
-        if a[1]:
-            string_key += f"c{a[0]}"
-        else:
-            string_key += f"a{a[0]}"
-    return string_key
+    return tuple(operator_string)
 
 
 def operator_to_qiskit_key(operator_string: list[tuple[int, bool]], remapping: dict[int, int]) -> str:
@@ -438,6 +432,24 @@ class FermionicOperator:
             else:
                 op_count[op_lenght] += 1
         return op_count
+
+    @property
+    def operator_readable(self) -> dict[str, float]:
+        """Get the operator in human readable format.
+
+        Returns:
+            Operator in humanreable format.
+        """
+        operator = {}
+        for string, fac in self.factors.items():
+            string_key = ""
+            for a in self.operators[string]:
+                if a[1]:
+                    string_key += f"c{a[0]}"
+                else:
+                    string_key += f"a{a[0]}"
+            operator[string_key] = fac
+        return operator
 
     def get_qiskit_form(self, num_orbs: int) -> dict[str, float]:
         """Get fermionic operator on qiskit form.

--- a/slowquant/unitary_coupled_cluster/fermionic_operator.py
+++ b/slowquant/unitary_coupled_cluster/fermionic_operator.py
@@ -32,18 +32,6 @@ def a_op_spin(spin_idx: int, dagger: bool) -> tuple[int, bool]:
     return (spin_idx, dagger)
 
 
-def operator_string_to_key(operator_string: list[tuple[int, bool]]) -> tuple[tuple[int, bool], ...]:
-    """Make key string to index a fermionic operator in a dict structure.
-
-    Args:
-        operator_string: Fermionic operators.
-
-    Returns:
-        Dictionary key.
-    """
-    return tuple(operator_string)
-
-
 def operator_to_qiskit_key(operator_string: list[tuple[int, bool]], remapping: dict[int, int]) -> str:
     """Make key string to index a fermionic operator in a dict structure.
 
@@ -134,7 +122,7 @@ def do_extended_normal_ordering(
                     break
             if not changed or is_zero:
                 if not is_zero:
-                    key_string = operator_string_to_key(next_operator)
+                    key_string = tuple(next_operator)
                     if key_string not in new_operators:
                         new_operators[key_string] = next_operator
                         new_factors[key_string] = factor
@@ -170,7 +158,7 @@ class FermionicOperator:
         if not isinstance(annihilation_operator, dict) and isinstance(factor, float):
             raise ValueError(f"factor cannot be dict when annihilation_operator is {type(a_op)}")
         if not isinstance(annihilation_operator, dict) and not isinstance(factor, dict):
-            string_key = operator_string_to_key([annihilation_operator])
+            string_key = tuple([annihilation_operator])
             self.operators = {}
             self.operators[string_key] = [annihilation_operator]
             self.factors = {}
@@ -408,7 +396,7 @@ class FermionicOperator:
                     new_op.append((op[0], False))
                 else:
                     new_op.append((op[0], True))
-            new_string_key = operator_string_to_key(new_op)
+            new_string_key = tuple(new_op)
             operators[new_string_key] = new_op
             factors[new_string_key] = self.factors[key_string]
         # Do normal ordering of comlex conjugated operator.
@@ -561,7 +549,7 @@ class FermionicOperator:
                 if i % 2 == 0:
                     ket_flip_fac *= -1
             fac *= ket_flip_fac
-            new_key = operator_string_to_key(active_op)
+            new_key = tuple(active_op)
             if new_key in factors:
                 factors[new_key] += fac * self.factors[key_string]
             else:

--- a/slowquant/unitary_coupled_cluster/fermionic_operator.py
+++ b/slowquant/unitary_coupled_cluster/fermionic_operator.py
@@ -54,7 +54,9 @@ def operator_to_qiskit_key(operator_string: list[tuple[int, bool]], remapping: d
 
 def do_extended_normal_ordering(
     fermistring: FermionicOperator,
-) -> tuple[dict[str, list[tuple[int, bool]]], dict[str, float]]:
+) -> tuple[
+    dict[tuple[tuple[int, bool], ...], list[tuple[int, bool]]], dict[tuple[tuple[int, bool], ...], float]
+]:
     """Reorder fermionic operator string.
 
     The string will be ordered such that all creation operators are first,
@@ -140,8 +142,8 @@ class FermionicOperator:
 
     def __init__(
         self,
-        annihilation_operator: dict[str, list[tuple[int, bool]]] | tuple[int, bool],
-        factor: dict[str, float] | float,
+        annihilation_operator: dict[tuple[tuple[int, bool], ...], list[tuple[int, bool]]] | tuple[int, bool],
+        factor: dict[tuple[tuple[int, bool], ...], float] | float,
     ) -> None:
         """Initialize fermionic operator class.
 
@@ -272,10 +274,10 @@ class FermionicOperator:
             factors = copy.copy(self.factors)
             for string_key in self.factors.keys():
                 # The name fermistring is misleading here.
-                factors[string_key] *= fermistring
+                factors[string_key] *= fermistring  # type: ignore
         elif type(fermistring) is FermionicOperator:
-            operators: dict[str, list[tuple[int, bool]]] = {}
-            factors: dict[str, float] = {}
+            operators = {}  # type: ignore
+            factors = {}  # type: ignore
             # Iterate over all strings in both FermionicOperators
             for string_key1 in fermistring.operators.keys():
                 for string_key2 in self.operators.keys():
@@ -317,10 +319,10 @@ class FermionicOperator:
         if type(fermistring) in (float, int):
             for string_key in self.factors.keys():
                 # The name fermistring is misleading here.
-                self.factors[string_key] *= fermistring
+                self.factors[string_key] *= fermistring  # type: ignore
         elif type(fermistring) is FermionicOperator:
-            operators: dict[str, list[tuple[int, bool]]] = {}
-            factors: dict[str, float] = {}
+            operators: dict[tuple[tuple[int, bool], ...], list[tuple[int, bool]]] = {}
+            factors: dict[tuple[tuple[int, bool], ...], float] = {}
             # Iterate over all strings in both FermionicOperators
             for string_key1 in fermistring.operators.keys():
                 for string_key2 in self.operators.keys():
@@ -493,8 +495,8 @@ class FermionicOperator:
         Returns:
            Folded fermionic operator.
         """
-        operators = {}
-        factors: dict[str, float] = {}
+        operators: dict[tuple[tuple[int, bool], ...], list[tuple[int, bool]]] = {}
+        factors: dict[tuple[tuple[int, bool], ...], float] = {}
         inactive_idx = []
         active_idx = []
         virtual_idx = []
@@ -554,5 +556,5 @@ class FermionicOperator:
                 factors[new_key] += fac * self.factors[key_string]
             else:
                 factors[new_key] = fac * self.factors[key_string]
-                operators[new_key] = active_op
+                operators[new_key] = active_op  # type: ignore
         return FermionicOperator(operators, factors)

--- a/slowquant/unitary_coupled_cluster/operator_state_algebra.py
+++ b/slowquant/unitary_coupled_cluster/operator_state_algebra.py
@@ -191,6 +191,8 @@ def apply_operator(
     tmp_state,
     factor,
 ):
+    anni_idxs = anni_idxs[::-1]
+    create_idxs = create_idxs[::-1]
     # loop over all determinants in new_state
     for i, det in enumerate(idx2det):
         if abs(new_state[i]) < 10**-14:
@@ -198,7 +200,7 @@ def apply_operator(
         phase_changes = 0
         is_killstate = False
         # evaluate how string of annihilation operator change det
-        for orb_idx in anni_idxs[::-1]:
+        for orb_idx in anni_idxs:
             if (det >> 2 * num_active_orbs - 1 - orb_idx) & 1 == 0:
                 is_killstate = True
                 break
@@ -207,7 +209,7 @@ def apply_operator(
             phase_changes += bitcount(det & parity_check[orb_idx])
         if is_killstate:
             continue
-        for orb_idx in create_idxs[::-1]:
+        for orb_idx in create_idxs:
             if (det >> 2 * num_active_orbs - 1 - orb_idx) & 1 == 1:
                 is_killstate = True
                 break
@@ -233,7 +235,7 @@ def apply_operator(
 def bitcount(x):
     b = 0
     while x > 0:
-        x &= nb.uint64(x - 1)  # x &= x - nb.uint64(1)  works too
+        x &= x - 1
         b += 1
     return b
 

--- a/slowquant/unitary_coupled_cluster/operator_state_algebra.py
+++ b/slowquant/unitary_coupled_cluster/operator_state_algebra.py
@@ -156,10 +156,10 @@ def propagate_state(
                 anni_idx = []
                 create_idx = []
                 for fermi_op in op_folded.operators[fermi_label]:
-                    if fermi_op.dagger:
-                        create_idx.append(fermi_op.idx)
+                    if fermi_op[1]:
+                        create_idx.append(fermi_op[0])
                     else:
-                        anni_idx.append(fermi_op.idx)
+                        anni_idx.append(fermi_op[0])
                 anni_idx = np.array(anni_idx, dtype=int)
                 create_idx = np.array(create_idx, dtype=int)
                 # loop over all determinants in new_state
@@ -167,7 +167,7 @@ def propagate_state(
                     phase_changes = 0
                     # evaluate how string of annihilation operator change det
                     for fermi_op in reversed(op_folded.operators[fermi_label]):
-                        orb_idx = fermi_op.idx
+                        orb_idx = fermi_op[0]
                         det = det ^ 2 ** (2 * num_active_orbs - 1 - orb_idx)
                         # take care of phases using parity_check
                         phase_changes += (det & parity_check[orb_idx]).bit_count()

--- a/slowquant/unitary_coupled_cluster/operator_state_algebra.py
+++ b/slowquant/unitary_coupled_cluster/operator_state_algebra.py
@@ -162,12 +162,35 @@ def propagate_state(
                         anni_idx.append(fermi_op[0])
                 anni_idx = np.array(anni_idx, dtype=np.int64)
                 create_idx = np.array(create_idx, dtype=np.int64)
-                tmp_state = apply_operator(new_state, anni_idx, create_idx, num_active_orbs, parity_check, idx2det, det2idx, do_unsafe, tmp_state, op_folded.factors[fermi_label])
+                tmp_state = apply_operator(
+                    new_state,
+                    anni_idx,
+                    create_idx,
+                    num_active_orbs,
+                    parity_check,
+                    idx2det,
+                    det2idx,
+                    do_unsafe,
+                    tmp_state,
+                    op_folded.factors[fermi_label],
+                )
             new_state = np.copy(tmp_state)
     return new_state
 
+
 @nb.jit(nopython=True)
-def apply_operator(new_state, anni_idxs, create_idxs, num_active_orbs, parity_check, idx2det, det2idx, do_unsafe, tmp_state, factor):
+def apply_operator(
+    new_state,
+    anni_idxs,
+    create_idxs,
+    num_active_orbs,
+    parity_check,
+    idx2det,
+    det2idx,
+    do_unsafe,
+    tmp_state,
+    factor,
+):
     # loop over all determinants in new_state
     for i, det in enumerate(idx2det):
         if abs(new_state[i]) < 10**-14:

--- a/slowquant/unitary_coupled_cluster/operators.py
+++ b/slowquant/unitary_coupled_cluster/operators.py
@@ -57,9 +57,11 @@ def epqrs(p: int, q: int, r: int, s: int) -> FermionicOperator:
     Returns:
         Singlet two-electron excitation operator.
     """
+    op = Epq(p, q)
+    op *= Epq(r, s)
     if q == r:
-        return Epq(p, q) * Epq(r, s) - Epq(p, s)
-    return Epq(p, q) * Epq(r, s)
+        op -= Epq(p, s)
+    return op
 
 
 def Eminuspq(p: int, q: int) -> FermionicOperator:
@@ -75,7 +77,9 @@ def Eminuspq(p: int, q: int) -> FermionicOperator:
     Returns:
         Singlet one-electron excitation operator.
     """
-    return Epq(p, q) - Epq(q, p)
+    op = Epq(p, q)
+    op -= Epq(q, p)
+    return op
 
 
 def commutator(A: FermionicOperator, B: FermionicOperator) -> FermionicOperator:
@@ -138,7 +142,7 @@ def G1(i: int, a: int, return_anti_hermitian: bool = False) -> FermionicOperator
     """
     op = FermionicOperator(a_op_spin(a, dagger=True), 1) * FermionicOperator(a_op_spin(i, dagger=False), 1)
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -198,7 +202,7 @@ def G3(
         * FermionicOperator(a_op_spin(i, dagger=False), 1)
     )
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -235,7 +239,7 @@ def G4(
         * FermionicOperator(a_op_spin(i, dagger=False), 1)
     )
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -286,7 +290,7 @@ def G5(
         * FermionicOperator(a_op_spin(i, dagger=False), 1)
     )
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -344,7 +348,7 @@ def G6(
         * FermionicOperator(a_op_spin(i, dagger=False), 1)
     )
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -364,7 +368,7 @@ def G1_sa(i: int, a: int, return_anti_hermitian: bool = False) -> FermionicOpera
     """
     op = 2 ** (-1 / 2) * Epq(a, i)
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -391,7 +395,7 @@ def G2_1_sa(i: int, j: int, a: int, b: int, return_anti_hermitian: bool = False)
         fac *= 2
     op = 1 / 2 * (fac) ** (-1 / 2) * (Epq(a, i) * Epq(b, j) + Epq(a, j) * Epq(b, i))
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -413,7 +417,7 @@ def G2_2_sa(i: int, j: int, a: int, b: int, return_anti_hermitian: bool = False)
     """
     op = 1 / (2 * 3 ** (1 / 2)) * (Epq(a, i) * Epq(b, j) - Epq(a, j) * Epq(b, i))
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 

--- a/slowquant/unitary_coupled_cluster/operators.py
+++ b/slowquant/unitary_coupled_cluster/operators.py
@@ -33,12 +33,11 @@ def Epq(p: int, q: int) -> FermionicOperator:
     Returns:
         Singlet one-electron excitation operator.
     """
-    E = FermionicOperator(a_op(p, "alpha", dagger=True), 1) * FermionicOperator(
-        a_op(q, "alpha", dagger=False), 1
-    )
-    E += FermionicOperator(a_op(p, "beta", dagger=True), 1) * FermionicOperator(
-        a_op(q, "beta", dagger=False), 1
-    )
+    E = FermionicOperator(a_op(p, "alpha", dagger=True), 1)
+    E *= FermionicOperator(a_op(q, "alpha", dagger=False), 1)
+    tmp = FermionicOperator(a_op(p, "beta", dagger=True), 1)
+    tmp *= FermionicOperator(a_op(q, "beta", dagger=False), 1)
+    E += tmp
     return E
 
 
@@ -140,7 +139,8 @@ def G1(i: int, a: int, return_anti_hermitian: bool = False) -> FermionicOperator
     Returns:
         One-electron excitation operator.
     """
-    op = FermionicOperator(a_op_spin(a, dagger=True), 1) * FermionicOperator(a_op_spin(i, dagger=False), 1)
+    op = FermionicOperator(a_op_spin(a, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(i, dagger=False), 1)
     if return_anti_hermitian:
         op -= op.dagger
     return op
@@ -162,14 +162,12 @@ def G2(i: int, j: int, a: int, b: int, return_anti_hermitian: bool = False) -> F
     Returns:
         Two-electron excitation operator.
     """
-    op = (
-        FermionicOperator(a_op_spin(a, dagger=True), 1)
-        * FermionicOperator(a_op_spin(b, dagger=True), 1)
-        * FermionicOperator(a_op_spin(j, dagger=False), 1)
-        * FermionicOperator(a_op_spin(i, dagger=False), 1)
-    )
+    op = FermionicOperator(a_op_spin(a, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(b, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(j, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(i, dagger=False), 1)
     if return_anti_hermitian:
-        return op - op.dagger
+        op -= op.dagger
     return op
 
 
@@ -193,14 +191,12 @@ def G3(
     Returns:
         Three-electron excitation operator.
     """
-    op = (
-        FermionicOperator(a_op_spin(a, dagger=True), 1)
-        * FermionicOperator(a_op_spin(b, dagger=True), 1)
-        * FermionicOperator(a_op_spin(c, dagger=True), 1)
-        * FermionicOperator(a_op_spin(k, dagger=False), 1)
-        * FermionicOperator(a_op_spin(j, dagger=False), 1)
-        * FermionicOperator(a_op_spin(i, dagger=False), 1)
-    )
+    op = FermionicOperator(a_op_spin(a, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(b, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(c, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(k, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(j, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(i, dagger=False), 1)
     if return_anti_hermitian:
         op -= op.dagger
     return op
@@ -228,16 +224,14 @@ def G4(
     Returns:
         Four-electron excitation operator.
     """
-    op = (
-        FermionicOperator(a_op_spin(a, dagger=True), 1)
-        * FermionicOperator(a_op_spin(b, dagger=True), 1)
-        * FermionicOperator(a_op_spin(c, dagger=True), 1)
-        * FermionicOperator(a_op_spin(d, dagger=True), 1)
-        * FermionicOperator(a_op_spin(l, dagger=False), 1)
-        * FermionicOperator(a_op_spin(k, dagger=False), 1)
-        * FermionicOperator(a_op_spin(j, dagger=False), 1)
-        * FermionicOperator(a_op_spin(i, dagger=False), 1)
-    )
+    op = FermionicOperator(a_op_spin(a, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(b, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(c, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(d, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(l, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(k, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(j, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(i, dagger=False), 1)
     if return_anti_hermitian:
         op -= op.dagger
     return op
@@ -277,18 +271,16 @@ def G5(
     Returns:
         Five-electron excitation operator.
     """
-    op = (
-        FermionicOperator(a_op_spin(a, dagger=True), 1)
-        * FermionicOperator(a_op_spin(b, dagger=True), 1)
-        * FermionicOperator(a_op_spin(c, dagger=True), 1)
-        * FermionicOperator(a_op_spin(d, dagger=True), 1)
-        * FermionicOperator(a_op_spin(e, dagger=True), 1)
-        * FermionicOperator(a_op_spin(m, dagger=False), 1)
-        * FermionicOperator(a_op_spin(l, dagger=False), 1)
-        * FermionicOperator(a_op_spin(k, dagger=False), 1)
-        * FermionicOperator(a_op_spin(j, dagger=False), 1)
-        * FermionicOperator(a_op_spin(i, dagger=False), 1)
-    )
+    op = FermionicOperator(a_op_spin(a, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(b, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(c, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(d, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(e, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(m, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(l, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(k, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(j, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(i, dagger=False), 1)
     if return_anti_hermitian:
         op -= op.dagger
     return op
@@ -333,20 +325,18 @@ def G6(
     Returns:
         Six-electron excitation operator.
     """
-    op = (
-        FermionicOperator(a_op_spin(a, dagger=True), 1)
-        * FermionicOperator(a_op_spin(b, dagger=True), 1)
-        * FermionicOperator(a_op_spin(c, dagger=True), 1)
-        * FermionicOperator(a_op_spin(d, dagger=True), 1)
-        * FermionicOperator(a_op_spin(e, dagger=True), 1)
-        * FermionicOperator(a_op_spin(f, dagger=True), 1)
-        * FermionicOperator(a_op_spin(n, dagger=False), 1)
-        * FermionicOperator(a_op_spin(m, dagger=False), 1)
-        * FermionicOperator(a_op_spin(l, dagger=False), 1)
-        * FermionicOperator(a_op_spin(k, dagger=False), 1)
-        * FermionicOperator(a_op_spin(j, dagger=False), 1)
-        * FermionicOperator(a_op_spin(i, dagger=False), 1)
-    )
+    op = FermionicOperator(a_op_spin(a, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(b, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(c, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(d, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(e, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(f, dagger=True), 1)
+    op *= FermionicOperator(a_op_spin(n, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(m, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(l, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(k, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(j, dagger=False), 1)
+    op *= FermionicOperator(a_op_spin(i, dagger=False), 1)
     if return_anti_hermitian:
         op -= op.dagger
     return op


### PR DESCRIPTION
The speed up is achieved through three different changes.

- An implementation of bitcount for Numba, which lets the performance-critical part of the code be JIT compiled.
- Changing the date structure of annihilation/creation operators to being tuples of integers and bools instead of class objects. This also allows for more direct indexing of det2idx.
- Implementation of in-place algebra for the FermionicOperator class. This avoids a lot of init calls and memory copies. 

Benchmark for wave function optimization using SLSQP with fUCCSD for Hydrogen chains with a distance of 0.8 Å.

| Active-space  | # parameters |  Old time per iteration (s) | New time per iteration  (s)|
|---|---|---|---|
| (2, 2)  | 3 |  3.1e-3 | 2.9e-3|
| (4, 4)  | 26 | 4.4e-2 | 3.3e-2 |
| (6, 6)  | 117 | 4.7e-1| 1.9e-1 |
| (8, 8)  | 360 | 10| 1.1 |
| (10, 10)  | 875 |  270 | 17 |
| (12, 12)  | 1818 | 7000 |  510 |
| (14, 14)  | 3381| >145000  | 17500  |