### PR TITLE
Bugfix for 1step optimizer in Circuit wave function. 

### DIFF
--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -1155,7 +1155,7 @@ class WaveFunctionCircuit:
             H = H.get_folded_operator(self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs)
             for i in range(len(parameters[num_kappa:])):
                 R = self.QI.grad_param_R[self.QI.param_names[i]]
-                e_vals_grad = _get_energy_evals_for_grad(H, self.QI, parameters, i, R)
+                e_vals_grad = _get_energy_evals_for_grad(H, self.QI, parameters[num_kappa:], i, R)
                 grad = 0.0
                 for j, mu in enumerate(list(range(1, 2 * R + 1))):
                     x_mu = (2 * mu - 1) / (2 * R) * np.pi


### PR DESCRIPTION
When using orbital optimisation in 1step VQE, the circuit wave function was passing all parameters (theta and kappa) to QI, leading to a error for a mismatch in parameters comparing passed parameters and free parameters in quantum circuit. 