### PR TITLE
Cleanup Wavefunction classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
+    rev: v2.3.1
     hooks:
       - id: mypy
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.4
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: mypy
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.1
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -1,6 +1,7 @@
+import copy
 import time
-from collections.abc import Sequence
 from functools import partial
+from typing import Any
 
 import numpy as np
 import pyscf
@@ -33,53 +34,76 @@ from slowquant.unitary_coupled_cluster.optimizers import Optimizers
 class WaveFunctionCircuit:
     def __init__(
         self,
-        cas: Sequence[int],
+        active_space: tuple[int, int] | tuple[tuple[int, int], int],
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         quantum_interface: QuantumInterface,
-        include_active_kappa: bool = False,
-        force_no_pp_mos: bool = False,
+        wavefunction_options: dict[str, Any] | None = None,
     ) -> None:
         """Initialize circuit based UPS wave function.
 
         Args:
-            cas: CAS(num_active_elec, num_active_orbs),
+            active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
                  orbitals are counted in spatial basis.
             mo_coeffs: Initial orbital coefficients.
             integral_generator: Integral generator object.
             quantum_interface: QuantumInterface.
-            include_active_kappa: Include active-active orbital rotations.
-            force_no_pp_mos: Switch of pp rotation of MOs even if do_pp is requested in QI.
+            wavefunction_options: Wavefunction options.
         """
-        if len(cas) != 2:
-            raise ValueError(f"cas must have two elements, got {len(cas)} elements.")
-        if isinstance(quantum_interface.ansatz, QuantumCircuit):
-            print(
-                "WARNING: A QI with a custom Ansatz was passed. VQE will only work with COBYLA and COBYQA optimizer."
-            )
+        if wavefunction_options is None:
+            wavefunction_options = {}
+        self.wavefunction_options = copy.deepcopy(wavefunction_options)
+        valid_options = (
+            "do_pp",
+            "resolve_unpaired_idx",
+            "include_active_kappa",
+            "reference_determinant",
+        )
+        for option in wavefunction_options:
+            if option not in valid_options:
+                raise ValueError(
+                    f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
+                )
+        # Default options
+        self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
+        self.wavefunction_options.setdefault("include_active_kappa", True)
+        self.wavefunction_options.setdefault("do_pp", False)
+        if len(active_space) != 2:
+            raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
+        if isinstance(active_space[0], int):
+            if active_space[0] % 2 == 0:
+                cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
+            else:
+                # Uneven number of electrons mean one electron must be unpaired.
+                cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
+        else:
+            cas = ((active_space[0][0], active_space[0][1]), active_space[1])
+        # Init stuff
         self.int_gen = IntegralManager(integral_generator)
-        self.inactive_spin_idx = []
-        self.virtual_spin_idx = []
-        self.active_spin_idx = []
-        self.active_occ_spin_idx = []
-        self.active_unocc_spin_idx = []
-        self.active_spin_idx_shifted = []
-        self.active_occ_spin_idx_shifted = []
-        self.active_unocc_spin_idx_shifted = []
-        self.active_idx_shifted = []
-        self.active_occ_idx_shifted = []
-        self.active_unocc_idx_shifted = []
-        self.num_elec = self.int_gen.num_elec
-        self.num_spin_orbs = 2 * len(self.int_gen.kinetic_energy)
-        self.num_orbs = len(self.int_gen.kinetic_energy)
-        self.num_active_elec = cas[0]
-        if self.num_active_elec % 2 != 0:
-            raise ValueError("Number of active electrons has to be even")
-        self.num_active_elec_alpha = self.num_active_elec // 2
-        self.num_active_elec_beta = self.num_active_elec // 2
-        self.num_active_spin_orbs = 0
-        self.num_inactive_spin_orbs = 0
-        self.num_virtual_spin_orbs = 0
+        if np.sum(cas[0]) > self.int_gen.num_elec:
+            raise ValueError("More active electrons than total number electrons.")
+        if (np.sum(cas[0]) % 2 == 0 and self.int_gen.num_elec % 2 == 1) or (
+            np.sum(cas[0]) % 2 == 1 and self.int_gen.num_elec % 2 == 0
+        ):
+            raise ValueError("Specified CAS gives odd number of electrons in inactive space.")
+        self.num_inactive_spin_orbs = self.int_gen.num_elec - int(np.sum(cas[0]))
+        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
+        self.num_active_orbs = cas[1]
+        self.num_active_spin_orbs = 2 * self.num_active_orbs
+        self.num_active_orbs = self.num_active_spin_orbs // 2
+        self.num_virtual_orbs = (
+            len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
+        )
+        if self.num_virtual_orbs < 0:
+            raise ValueError(
+                "Number of inactive + number of active orbitals is larger than total number of orbitals."
+            )
+        self.num_virtual_spin_orbs = 2 * self.num_virtual_orbs
+        self.num_orbs = self.num_inactive_orbs + self.num_active_orbs + self.num_virtual_orbs
+        self.num_spin_orbs = 2 * self.num_orbs
+        self.num_active_elec_alpha = cas[0][0]
+        self.num_active_elec_beta = cas[0][1]
+        self.num_active_elec = self.num_active_elec_alpha + self.num_active_elec_beta
         self._rdm1 = None
         self._rdm2 = None
         self._rdm3 = None
@@ -87,120 +111,19 @@ class WaveFunctionCircuit:
         self._h_mo = None
         self._g_mo = None
         self._energy_elec: float | None = None
-        self.num_energy_evals = 0  # number of energy measurements on quanutm
-        active_space = []
-        orbital_counter = 0
-        num_elec = self.int_gen.num_elec
-        for i in range(num_elec - cas[0], num_elec):
-            active_space.append(i)
-            orbital_counter += 1
-        for i in range(num_elec, num_elec + 2 * cas[1] - orbital_counter):
-            active_space.append(i)
-        for i in range(num_elec):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_occ_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-            else:
-                self.inactive_spin_idx.append(i)
-                self.num_inactive_spin_orbs += 1
-        for i in range(num_elec, self.num_spin_orbs):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_unocc_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-            else:
-                self.virtual_spin_idx.append(i)
-                self.num_virtual_spin_orbs += 1
-        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
-        self.num_active_orbs = self.num_active_spin_orbs // 2
-        self.num_virtual_orbs = self.num_virtual_spin_orbs // 2
-        # Construct spatial idx
-        self.inactive_idx: list[int] = []
-        self.virtual_idx: list[int] = []
-        self.active_idx: list[int] = []
-        self.active_occ_idx: list[int] = []
-        self.active_unocc_idx: list[int] = []
-        for idx in self.inactive_spin_idx:
-            if idx // 2 not in self.inactive_idx:
-                self.inactive_idx.append(idx // 2)
-        for idx in self.active_spin_idx:
-            if idx // 2 not in self.active_idx:
-                self.active_idx.append(idx // 2)
-        for idx in self.virtual_spin_idx:
-            if idx // 2 not in self.virtual_idx:
-                self.virtual_idx.append(idx // 2)
-        for idx in self.active_occ_spin_idx:
-            if idx // 2 not in self.active_occ_idx:
-                self.active_occ_idx.append(idx // 2)
-        for idx in self.active_unocc_spin_idx:
-            if idx // 2 not in self.active_unocc_idx:
-                self.active_unocc_idx.append(idx // 2)
-        # Make shifted indices
-        if len(self.active_spin_idx) != 0:
-            active_shift = np.min(self.active_spin_idx)
-            for active_idx in self.active_spin_idx:
-                self.active_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_spin_idx:
-                self.active_occ_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_spin_idx:
-                self.active_unocc_spin_idx_shifted.append(active_idx - active_shift)
-        if len(self.active_idx) != 0:
-            active_shift = np.min(self.active_idx)
-            for active_idx in self.active_idx:
-                self.active_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_idx:
-                self.active_occ_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_idx:
-                self.active_unocc_idx_shifted.append(active_idx - active_shift)
-        # Find non-redundant kappas
-        self._kappa = []
-        kappa_idx = []
-        kappa_no_activeactive_idx = []
-        kappa_no_activeactive_idx_dagger = []
-        kappa_redundant_idx = []
-        self._kappa_old = []
-        # kappa can be optimized in spatial basis
-        for p in range(0, self.num_orbs):
-            for q in range(p + 1, self.num_orbs):
-                if p in self.inactive_idx and q in self.inactive_idx:
-                    kappa_redundant_idx.append((p, q))
-                    continue
-                if p in self.virtual_idx and q in self.virtual_idx:
-                    kappa_redundant_idx.append((p, q))
-                    continue
-                if not include_active_kappa:
-                    if p in self.active_idx and q in self.active_idx:
-                        kappa_redundant_idx.append((p, q))
-                        continue
-                if not (p in self.active_idx and q in self.active_idx):
-                    kappa_no_activeactive_idx.append((p, q))
-                    kappa_no_activeactive_idx_dagger.append((q, p))
-                self._kappa.append(0.0)
-                self._kappa_old.append(0.0)
-                kappa_idx.append((p, q))
-        # HF like orbital rotation indices
-        kappa_hf_like_idx = []
-        for p in range(0, self.num_orbs):
-            for q in range(p + 1, self.num_orbs):
-                if p in self.inactive_idx and q in self.virtual_idx:
-                    kappa_hf_like_idx.append((p, q))
-                elif p in self.inactive_idx and q in self.active_unocc_idx:
-                    kappa_hf_like_idx.append((p, q))
-                elif p in self.active_occ_idx and q in self.virtual_idx:
-                    kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=int)
-        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
-        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
-        # Re-order MOs for perfect pairing
-        if (
-            "do_pp" in quantum_interface.ansatz_options.keys()
-            and quantum_interface.ansatz_options["do_pp"]
-            and not force_no_pp_mos
-        ):
-            hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
+        self.num_energy_evals = 0
+        self._c_mo = mo_coeffs
+        # Reference wave function
+        self._pp = self.wavefunction_options["do_pp"]
+        if self.wavefunction_options["do_pp"]:
+            if "reference_determinant" in self.wavefunction_options.keys():
+                raise ValueError(
+                    "Both 'do_pp' and 'reference_determinant' are requested in 'wavefunction_options'."
+                )
+            if self.num_active_elec_alpha != self.num_active_elec_beta:
+                raise ValueError(
+                    "perfect-pairing is only defined for equal number of alpha and beta electrons."
+                )
             # Obtain pp determinant
             pp_det = ""
             spin_orb = 0
@@ -221,20 +144,142 @@ class WaveFunctionCircuit:
                     pp_det += "1"
                     spin_orb += 1
                     elec_count -= 1
-            print("MO rotations: perfect-pairing determinant found as:", pp_det)
             if len(pp_det) != self.num_active_spin_orbs or pp_det.count("1") != self.num_active_elec:
                 raise ValueError("Perfect pairing determinant violates orbital or electron numbers")
 
             # Swap mo coefficients to resembles pp layout
+            hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
             hole = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "1" and p == "0"]
             part = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "0" and p == "1"]
             hole_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in hole))
             part_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in part))
             pp_mo_coeffs = mo_coeffs.copy()
             pp_mo_coeffs[:, hole_spatial + part_spatial] = pp_mo_coeffs[:, part_spatial + hole_spatial]
+            # Note self._c_mo is set previously but overwritten here.
             self._c_mo = pp_mo_coeffs
+
+            # Assign weight to reference
+            ref_det = pp_det
+        elif "reference_determinant" in self.wavefunction_options.keys():
+            ref_det = self.wavefunction_options["reference_determinant"]
+            if len(ref_det) != self.num_active_spin_orbs:
+                raise ValueError(
+                    f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
+                )
+            ref_alpha = 0
+            ref_beta = 0
+            for i, idx in ref_det:
+                if i % 2 == 0 and idx == "1":
+                    ref_alpha += 1
+                elif idx == "1":
+                    ref_beta += 1
+            if ref_alpha != self.num_active_elec_alpha or ref_beta != self.num_active_elec_beta:
+                raise ValueError(
+                    "Number of electrons ({ref_alpha}, {ref_beta}) is different from the active space ({self.num_active_elec_alpha, self.num_active_elec_beta})."
+                )
         else:
-            self._c_mo = mo_coeffs
+            ref_det = ""
+            for i in range(self.num_active_orbs):
+                if i < self.num_active_elec_alpha:
+                    ref_det += "1"
+                else:
+                    ref_det += "0"
+                if i < self.num_active_elec_beta:
+                    ref_det += "1"
+                else:
+                    ref_det += "0"
+        # Construct spin orbital indices
+        self.inactive_spin_idx = [x for x in range(self.num_inactive_spin_orbs)]
+        self.active_spin_idx = [x + self.num_inactive_spin_orbs for x in range(self.num_active_spin_orbs)]
+        self.virtual_spin_idx = [
+            x + self.num_inactive_spin_orbs + self.num_active_spin_orbs
+            for x in range(self.num_virtual_spin_orbs)
+        ]
+        self.active_occ_spin_idx = []
+        self.active_unocc_spin_idx = []
+        for i, orb_idx in enumerate(self.active_spin_idx):
+            if ref_det[i] == "1":
+                self.active_occ_spin_idx.append(orb_idx)
+            else:
+                self.active_unocc_spin_idx.append(orb_idx)
+        self.active_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_spin_idx]
+        self.active_occ_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_occ_spin_idx]
+        self.active_unocc_spin_idx_shifted = [
+            x - self.num_inactive_spin_orbs for x in self.active_unocc_spin_idx
+        ]
+        # Construct spatial idx
+        self.inactive_idx = [x for x in range(self.num_inactive_orbs)]
+        self.active_idx = [x + self.num_inactive_orbs for x in range(self.num_active_orbs)]
+        self.virtual_idx = [
+            x + self.num_inactive_orbs + self.num_active_orbs for x in range(self.num_virtual_orbs)
+        ]
+        self.active_occ_idx = []
+        self.active_unocc_idx = []
+        for i, orb_idx in enumerate(self.active_idx):
+            if ref_det[2 * i] == "1" and ref_det[2 * i + 1] == "1":
+                self.active_occ_idx.append(orb_idx)
+            elif ref_det[2 * i] == "0" and ref_det[2 * i + 1] == "0":
+                self.active_unocc_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "both":
+                self.active_occ_idx.append(orb_idx)
+                self.active_unocc_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
+                self.active_occ_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
+                self.active_unocc_idx.append(orb_idx)
+            else:
+                raise ValueError(
+                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, excpected 'both', 'occ' or 'unocc'."
+                )
+        self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
+        self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
+        self.active_unocc_idx_shifted = [x - self.num_inactive_orbs for x in self.active_unocc_idx]
+        # Find non-redundant kappas
+        self._kappa = []
+        kappa_idx = []
+        kappa_no_activeactive_idx = []
+        kappa_no_activeactive_idx_dagger = []
+        self._kappa_old = []
+        # kappa can be optimized in spatial basis
+        # Loop over all q>p orb combinations and find redundant kappas
+        for p in range(0, self.num_orbs):
+            for q in range(p + 1, self.num_orbs):
+                # find redundant kappas
+                if p in self.inactive_idx and q in self.inactive_idx:
+                    continue
+                if p in self.virtual_idx and q in self.virtual_idx:
+                    continue
+                if not self.wavefunction_options["include_active_kappa"]:
+                    if p in self.active_idx and q in self.active_idx:
+                        continue
+                if not (p in self.active_idx and q in self.active_idx):
+                    kappa_no_activeactive_idx.append((p, q))
+                    kappa_no_activeactive_idx_dagger.append((q, p))
+                # the rest is non-redundant
+                self._kappa.append(0.0)
+                self._kappa_old.append(0.0)
+                kappa_idx.append((p, q))
+        # HF like orbital rotation indices
+        kappa_hf_like_idx = []
+        for p in range(0, self.num_orbs):
+            for q in range(p + 1, self.num_orbs):
+                if p in self.inactive_idx and q in self.virtual_idx:
+                    kappa_hf_like_idx.append((p, q))
+                elif p in self.inactive_idx and q in self.active_unocc_idx:
+                    kappa_hf_like_idx.append((p, q))
+                elif p in self.active_occ_idx and q in self.virtual_idx:
+                    kappa_hf_like_idx.append((p, q))
+        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
+        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=np.int64)
+        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=np.int64)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
+        hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
+        if ref_det == hf_det:
+            # If the refernce determinant is just Hartree-Fock,
+            # then reconstruct it inside QI to allow for other mappers than JW.
+            self.ref_det = None
+        else:
+            self.ref_det = ref_det
         # Setup Quantum Interface
         self.QI = quantum_interface
         self.QI.construct_circuit(
@@ -244,6 +289,7 @@ class WaveFunctionCircuit:
             self.active_unocc_spin_idx_shifted,
             self.num_active_orbs,
             (self.num_active_elec_alpha, self.num_active_elec_beta),
+            ref_det=self.ref_det,
         )
 
     @property
@@ -380,6 +426,7 @@ class WaveFunctionCircuit:
             self.active_unocc_spin_idx_shifted,
             self.num_active_orbs,
             (self.num_active_elec_alpha, self.num_active_elec_beta),
+            ref_det=self.ref_det,
         )
 
     @property
@@ -395,17 +442,17 @@ class WaveFunctionCircuit:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs))
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=np.float64)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     rdm1_op = Epq(p, q).get_folded_operator(
                         self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs
                     )
                     val = self.QI.quantum_expectation_value(rdm1_op)
-                    self._rdm1[p_idx, q_idx] = val  # type: ignore [index]
-                    self._rdm1[q_idx, p_idx] = val  # type: ignore [index]
+                    self._rdm1[p_, q_] = val  # type: ignore [index]
+                    self._rdm1[q_, p_] = val  # type: ignore [index]
         return self._rdm1
 
     @property
@@ -427,14 +474,15 @@ class WaveFunctionCircuit:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         if p == q:
                             s_lim = r + 1
                         elif p == r:
@@ -444,17 +492,17 @@ class WaveFunctionCircuit:
                         else:
                             s_lim = p + 1
                         for s in range(self.num_inactive_orbs, s_lim):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             pdm2_op = (Epq(p, q) * Epq(r, s)).get_folded_operator(
                                 self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs
                             )
                             val = self.QI.quantum_expectation_value(pdm2_op)
                             if q == r:
-                                val -= self.rdm1[p_idx, s_idx]
-                            self._rdm2[p_idx, q_idx, r_idx, s_idx] = val  # type: ignore [index]
-                            self._rdm2[r_idx, s_idx, p_idx, q_idx] = val  # type: ignore [index]
-                            self._rdm2[q_idx, p_idx, s_idx, r_idx] = val  # type: ignore [index]
-                            self._rdm2[s_idx, r_idx, q_idx, p_idx] = val  # type: ignore [index]
+                                val -= self.rdm1[p_, s_]
+                            self._rdm2[p_, q_, r_, s_] = val  # type: ignore
+                            self._rdm2[r_, s_, p_, q_] = val  # type: ignore
+                            self._rdm2[q_, p_, s_, r_] = val  # type: ignore
+                            self._rdm2[s_, r_, q_, p_] = val  # type: ignore
         return self._rdm2
 
     @property
@@ -478,44 +526,45 @@ class WaveFunctionCircuit:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         for s in range(self.num_inactive_orbs, p + 1):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             for t in range(self.num_inactive_orbs, r + 1):
-                                t_idx = t - self.num_inactive_orbs
+                                t_ = t - self.num_inactive_orbs
                                 for u in range(self.num_inactive_orbs, p + 1):
-                                    u_idx = u - self.num_inactive_orbs
+                                    u_ = u - self.num_inactive_orbs
                                     pdm3_op = (Epq(p, q) * Epq(r, s) * Epq(t, u)).get_folded_operator(
                                         self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs
                                     )
                                     val = self.QI.quantum_expectation_value(pdm3_op)
                                     if t == s:
-                                        val -= self.rdm2[p_idx, q_idx, r_idx, u_idx]
+                                        val -= self.rdm2[p_, q_, r_, u_]
                                     if r == q:
-                                        val -= self.rdm2[p_idx, s_idx, t_idx, u_idx]
+                                        val -= self.rdm2[p_, s_, t_, u_]
                                     if t == q:
-                                        val -= self.rdm2[p_idx, u_idx, r_idx, s_idx]
+                                        val -= self.rdm2[p_, u_, r_, s_]
                                     if t == s and r == q:
-                                        val -= self.rdm1[p_idx, u_idx]
-                                    self._rdm3[p_idx, q_idx, r_idx, s_idx, t_idx, u_idx] = val  # type: ignore
-                                    self._rdm3[p_idx, q_idx, t_idx, u_idx, r_idx, s_idx] = val  # type: ignore
-                                    self._rdm3[r_idx, s_idx, p_idx, q_idx, t_idx, u_idx] = val  # type: ignore
-                                    self._rdm3[r_idx, s_idx, t_idx, u_idx, p_idx, q_idx] = val  # type: ignore
-                                    self._rdm3[t_idx, u_idx, p_idx, q_idx, r_idx, s_idx] = val  # type: ignore
-                                    self._rdm3[t_idx, u_idx, r_idx, s_idx, p_idx, q_idx] = val  # type: ignore
-                                    self._rdm3[q_idx, p_idx, s_idx, r_idx, u_idx, t_idx] = val  # type: ignore
-                                    self._rdm3[q_idx, p_idx, u_idx, t_idx, s_idx, r_idx] = val  # type: ignore
-                                    self._rdm3[s_idx, r_idx, q_idx, p_idx, u_idx, t_idx] = val  # type: ignore
-                                    self._rdm3[s_idx, r_idx, u_idx, t_idx, q_idx, p_idx] = val  # type: ignore
-                                    self._rdm3[u_idx, t_idx, q_idx, p_idx, s_idx, r_idx] = val  # type: ignore
-                                    self._rdm3[u_idx, t_idx, s_idx, r_idx, q_idx, p_idx] = val  # type: ignore
+                                        val -= self.rdm1[p_, u_]
+                                    self._rdm3[p_, q_, r_, s_, t_, u_] = val  # type: ignore
+                                    self._rdm3[p_, q_, t_, u_, r_, s_] = val  # type: ignore
+                                    self._rdm3[r_, s_, p_, q_, t_, u_] = val  # type: ignore
+                                    self._rdm3[r_, s_, t_, u_, p_, q_] = val  # type: ignore
+                                    self._rdm3[t_, u_, p_, q_, r_, s_] = val  # type: ignore
+                                    self._rdm3[t_, u_, r_, s_, p_, q_] = val  # type: ignore
+                                    self._rdm3[q_, p_, s_, r_, u_, t_] = val  # type: ignore
+                                    self._rdm3[q_, p_, u_, t_, s_, r_] = val  # type: ignore
+                                    self._rdm3[s_, r_, q_, p_, u_, t_] = val  # type: ignore
+                                    self._rdm3[s_, r_, u_, t_, q_, p_] = val  # type: ignore
+                                    self._rdm3[u_, t_, q_, p_, s_, r_] = val  # type: ignore
+                                    self._rdm3[u_, t_, s_, r_, q_, p_] = val  # type: ignore
         return self._rdm3
 
     @property
@@ -541,24 +590,25 @@ class WaveFunctionCircuit:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         for s in range(self.num_inactive_orbs, p + 1):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             for t in range(self.num_inactive_orbs, r + 1):
-                                t_idx = t - self.num_inactive_orbs
+                                t_ = t - self.num_inactive_orbs
                                 for u in range(self.num_inactive_orbs, p + 1):
-                                    u_idx = u - self.num_inactive_orbs
+                                    u_ = u - self.num_inactive_orbs
                                     for m in range(self.num_inactive_orbs, t + 1):
-                                        m_idx = m - self.num_inactive_orbs
+                                        m_ = m - self.num_inactive_orbs
                                         for n in range(self.num_inactive_orbs, p + 1):
-                                            n_idx = n - self.num_inactive_orbs
+                                            n_ = n - self.num_inactive_orbs
                                             pdm4_op = (
                                                 Epq(p, q) * Epq(r, s) * Epq(t, u) * Epq(m, n)
                                             ).get_folded_operator(
@@ -568,177 +618,81 @@ class WaveFunctionCircuit:
                                             )
                                             val = self.QI.quantum_expectation_value(pdm4_op)
                                             if r == q:
-                                                val -= self.rdm3[p_idx, s_idx, t_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, s_, t_, u_, m_, n_]
                                             if t == q:
-                                                val -= self.rdm3[p_idx, u_idx, r_idx, s_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, u_, r_, s_, m_, n_]
                                             if m == q:
-                                                val -= self.rdm3[p_idx, n_idx, r_idx, s_idx, t_idx, u_idx]
+                                                val -= self.rdm3[p_, n_, r_, s_, t_, u_]
                                             if m == u:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, s_idx, t_idx, n_idx]
+                                                val -= self.rdm3[p_, q_, r_, s_, t_, n_]
                                             if t == s:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, q_, r_, u_, m_, n_]
                                             if m == s:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, n_idx, t_idx, u_idx]
+                                                val -= self.rdm3[p_, q_, r_, n_, t_, u_]
                                             if m == u and r == q:
-                                                val -= self.rdm2[p_idx, s_idx, t_idx, n_idx]
+                                                val -= self.rdm2[p_, s_, t_, n_]
                                             if m == u and t == q:
-                                                val -= self.rdm2[p_idx, n_idx, r_idx, s_idx]
+                                                val -= self.rdm2[p_, n_, r_, s_]
                                             if t == s and m == u:
-                                                val -= self.rdm2[p_idx, q_idx, r_idx, n_idx]
+                                                val -= self.rdm2[p_, q_, r_, n_]
                                             if t == s and r == q:
-                                                val -= self.rdm2[p_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm2[p_, u_, m_, n_]
                                             if t == s and m == q:
-                                                val -= self.rdm2[p_idx, n_idx, r_idx, u_idx]
+                                                val -= self.rdm2[p_, n_, r_, u_]
                                             if m == s and r == q:
-                                                val -= self.rdm2[p_idx, n_idx, t_idx, u_idx]
+                                                val -= self.rdm2[p_, n_, t_, u_]
                                             if m == s and t == q:
-                                                val -= self.rdm2[p_idx, u_idx, r_idx, n_idx]
+                                                val -= self.rdm2[p_, u_, r_, n_]
                                             if m == u and t == s and r == q:
-                                                val -= self.rdm1[p_idx, n_idx]
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, r_idx, s_idx, t_idx, u_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, r_idx, s_idx, m_idx, n_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, t_idx, u_idx, r_idx, s_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, t_idx, u_idx, m_idx, n_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, m_idx, n_idx, r_idx, s_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, m_idx, n_idx, t_idx, u_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, p_idx, q_idx, t_idx, u_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, p_idx, q_idx, m_idx, n_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, t_idx, u_idx, p_idx, q_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, t_idx, u_idx, m_idx, n_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, m_idx, n_idx, p_idx, q_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, m_idx, n_idx, t_idx, u_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, p_idx, q_idx, r_idx, s_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, p_idx, q_idx, m_idx, n_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, r_idx, s_idx, p_idx, q_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, r_idx, s_idx, m_idx, n_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, m_idx, n_idx, p_idx, q_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, m_idx, n_idx, r_idx, s_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, p_idx, q_idx, r_idx, s_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, p_idx, q_idx, t_idx, u_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, r_idx, s_idx, p_idx, q_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, r_idx, s_idx, t_idx, u_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, t_idx, u_idx, p_idx, q_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, t_idx, u_idx, r_idx, s_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, s_idx, r_idx, u_idx, t_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, s_idx, r_idx, n_idx, m_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, u_idx, t_idx, s_idx, r_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, u_idx, t_idx, n_idx, m_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, n_idx, m_idx, s_idx, r_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, n_idx, m_idx, u_idx, t_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, q_idx, p_idx, u_idx, t_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, q_idx, p_idx, n_idx, m_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, u_idx, t_idx, q_idx, p_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, u_idx, t_idx, n_idx, m_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, n_idx, m_idx, q_idx, p_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, n_idx, m_idx, u_idx, t_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, q_idx, p_idx, s_idx, r_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, q_idx, p_idx, n_idx, m_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, s_idx, r_idx, q_idx, p_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, s_idx, r_idx, n_idx, m_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, n_idx, m_idx, q_idx, p_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, n_idx, m_idx, s_idx, r_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, q_idx, p_idx, s_idx, r_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, q_idx, p_idx, u_idx, t_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, s_idx, r_idx, q_idx, p_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, s_idx, r_idx, u_idx, t_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, u_idx, t_idx, q_idx, p_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, u_idx, t_idx, s_idx, r_idx, q_idx, p_idx
-                                            ] = val
+                                                val -= self.rdm1[p_, n_]
+                                            self._rdm4[p_, q_, r_, s_, t_, u_, m_, n_] = val  # type: ignore
+                                            self._rdm4[p_, q_, r_, s_, m_, n_, t_, u_] = val  # type: ignore
+                                            self._rdm4[p_, q_, t_, u_, r_, s_, m_, n_] = val  # type: ignore
+                                            self._rdm4[p_, q_, t_, u_, m_, n_, r_, s_] = val  # type: ignore
+                                            self._rdm4[p_, q_, m_, n_, r_, s_, t_, u_] = val  # type: ignore
+                                            self._rdm4[p_, q_, m_, n_, t_, u_, r_, s_] = val  # type: ignore
+                                            self._rdm4[r_, s_, p_, q_, t_, u_, m_, n_] = val  # type: ignore
+                                            self._rdm4[r_, s_, p_, q_, m_, n_, t_, u_] = val  # type: ignore
+                                            self._rdm4[r_, s_, t_, u_, p_, q_, m_, n_] = val  # type: ignore
+                                            self._rdm4[r_, s_, t_, u_, m_, n_, p_, q_] = val  # type: ignore
+                                            self._rdm4[r_, s_, m_, n_, p_, q_, t_, u_] = val  # type: ignore
+                                            self._rdm4[r_, s_, m_, n_, t_, u_, p_, q_] = val  # type: ignore
+                                            self._rdm4[t_, u_, p_, q_, r_, s_, m_, n_] = val  # type: ignore
+                                            self._rdm4[t_, u_, p_, q_, m_, n_, r_, s_] = val  # type: ignore
+                                            self._rdm4[t_, u_, r_, s_, p_, q_, m_, n_] = val  # type: ignore
+                                            self._rdm4[t_, u_, r_, s_, m_, n_, p_, q_] = val  # type: ignore
+                                            self._rdm4[t_, u_, m_, n_, p_, q_, r_, s_] = val  # type: ignore
+                                            self._rdm4[t_, u_, m_, n_, r_, s_, p_, q_] = val  # type: ignore
+                                            self._rdm4[m_, n_, p_, q_, r_, s_, t_, u_] = val  # type: ignore
+                                            self._rdm4[m_, n_, p_, q_, t_, u_, r_, s_] = val  # type: ignore
+                                            self._rdm4[m_, n_, r_, s_, p_, q_, t_, u_] = val  # type: ignore
+                                            self._rdm4[m_, n_, r_, s_, t_, u_, p_, q_] = val  # type: ignore
+                                            self._rdm4[m_, n_, t_, u_, p_, q_, r_, s_] = val  # type: ignore
+                                            self._rdm4[m_, n_, t_, u_, r_, s_, p_, q_] = val  # type: ignore
+                                            self._rdm4[q_, p_, s_, r_, u_, t_, n_, m_] = val  # type: ignore
+                                            self._rdm4[q_, p_, s_, r_, n_, m_, u_, t_] = val  # type: ignore
+                                            self._rdm4[q_, p_, u_, t_, s_, r_, n_, m_] = val  # type: ignore
+                                            self._rdm4[q_, p_, u_, t_, n_, m_, s_, r_] = val  # type: ignore
+                                            self._rdm4[q_, p_, n_, m_, s_, r_, u_, t_] = val  # type: ignore
+                                            self._rdm4[q_, p_, n_, m_, u_, t_, s_, r_] = val  # type: ignore
+                                            self._rdm4[s_, r_, q_, p_, u_, t_, n_, m_] = val  # type: ignore
+                                            self._rdm4[s_, r_, q_, p_, n_, m_, u_, t_] = val  # type: ignore
+                                            self._rdm4[s_, r_, u_, t_, q_, p_, n_, m_] = val  # type: ignore
+                                            self._rdm4[s_, r_, u_, t_, n_, m_, q_, p_] = val  # type: ignore
+                                            self._rdm4[s_, r_, n_, m_, q_, p_, u_, t_] = val  # type: ignore
+                                            self._rdm4[s_, r_, n_, m_, u_, t_, q_, p_] = val  # type: ignore
+                                            self._rdm4[u_, t_, q_, p_, s_, r_, n_, m_] = val  # type: ignore
+                                            self._rdm4[u_, t_, q_, p_, n_, m_, s_, r_] = val  # type: ignore
+                                            self._rdm4[u_, t_, s_, r_, q_, p_, n_, m_] = val  # type: ignore
+                                            self._rdm4[u_, t_, s_, r_, n_, m_, q_, p_] = val  # type: ignore
+                                            self._rdm4[u_, t_, n_, m_, q_, p_, s_, r_] = val  # type: ignore
+                                            self._rdm4[u_, t_, n_, m_, s_, r_, q_, p_] = val  # type: ignore
+                                            self._rdm4[n_, m_, q_, p_, s_, r_, u_, t_] = val  # type: ignore
+                                            self._rdm4[n_, m_, q_, p_, u_, t_, s_, r_] = val  # type: ignore
+                                            self._rdm4[n_, m_, s_, r_, q_, p_, u_, t_] = val  # type: ignore
+                                            self._rdm4[n_, m_, s_, r_, u_, t_, q_, p_] = val  # type: ignore
+                                            self._rdm4[n_, m_, u_, t_, q_, p_, s_, r_] = val  # type: ignore
+                                            self._rdm4[n_, m_, u_, t_, s_, r_, q_, p_] = val  # type: ignore
         return self._rdm4
 
     def precalc_rdm_paulis(self, rdm_order: int) -> None:
@@ -832,16 +786,13 @@ class WaveFunctionCircuit:
             SparsePauliOp(cumulated_paulis, np.ones(len(cumulated_paulis)))  # type: ignore[arg-type]
         )
 
-    def check_orthonormality(self, overlap_integral: np.ndarray) -> None:
+    def check_orthonormality(self) -> None:
         r"""Check orthonormality of orbitals.
 
         .. math::
             \boldsymbol{I} = \boldsymbol{C}_\text{MO}\boldsymbol{S}\boldsymbol{C}_\text{MO}^T
-
-        Args:
-            overlap_integral: Overlap integral in AO basis.
         """
-        S_ortho = one_electron_integral_transform(self.c_mo, overlap_integral)
+        S_ortho = one_electron_integral_transform(self.c_mo, self.int_gen.overlap)
         one = np.identity(len(S_ortho))
         diff = np.abs(S_ortho - one)
         print("Max ortho-normal diff:", np.max(diff))
@@ -881,42 +832,123 @@ class WaveFunctionCircuit:
         energy_elec = self.QI.quantum_expectation_value(H)
         return energy_elec
 
-    def run_wf_optimization_2step(
+    def run_wf_optimization(
         self,
-        optimizer_name: str,
         orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
-        is_silent_subiterations: bool = False,
-        print_std: bool = False,
+        optimization_options: dict[str, Any] | None = None,
     ) -> None:
-        """Run two step optimization of wave function.
+        """Run variational optimization of wavefunction.
+
+        Optimization options:
+            * theta_optimization [bool]: Perform theta optimization.
+                                         (default: True)
+            * theta_optimizer [str]: Optimizer used for theta optimization.
+                                     (default: BFGS)
+            * orbital_optimizer [str]: Optimizer used for orbital optimization.
+                                     (default: BFGS)
+            * 1step_optimizer [str]: Optimizer used for 1step optimizer.
+                                     (fallback: copy theta_optimizer)
+            * opt_type [str]: Optimization type, can be '1step' or '2step'.
+                              (default: 1step)
+            * is_silent_subiterations [bool]: Silence sub iterations in 2step.
+                                              (default: False)
+            * print_std [bool]: Print standard deviation of the electronic Hamiltonian during optimization.
+                                (default: False)
 
         Args:
-            optimizer_name: Name of optimizer.
             orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
+            tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            is_silent_subiterations: Silence subiterations.
-            print_std: Print standard deviation of the electronic Hamiltonian during optimization.
+            optimization_options: Additional optimization options.
         """
-        if isinstance(self.QI.ansatz, QuantumCircuit) and optimizer_name.lower() not in ("cobyla", "cobyqa"):
-            raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
+        if optimization_options is None:
+            optimization_options = {}
+        self._optimization_options = copy.deepcopy(optimization_options)
+        valid_options = (
+            "theta_optimization",
+            "theta_optimizer",
+            "orbital_optimizer",
+            "opt_type",
+            "is_silent_subiterations",
+            "1step_optimizer",
+            "print_std",
+        )
+        for option in self._optimization_options:
+            if option not in valid_options:
+                raise ValueError(
+                    f"Got unknown option for optimization, {option}. Valid options are: {valid_options}"
+                )
+        self._optimization_options["tol"] = tol
+        self._optimization_options["maxiter"] = int(maxiter)
+        self._optimization_options["orbital_optimization"] = orbital_optimization
+        self._optimization_options.setdefault("theta_optimization", True)
+        self._optimization_options.setdefault("theta_optimizer", "BFGS")
+        self._optimization_options.setdefault("orbital_optimizer", "BFGS")
+        self._optimization_options.setdefault("opt_type", "1step")
+        self._optimization_options.setdefault("is_silent_subiterations", False)
+        self._optimization_options.setdefault("print_std", False)
+        if len(self.kappa) == 0 and self._optimization_options["orbital_optimization"]:
+            print("No kappa parameters turning off orbital optimization.")
+        if len(self.thetas) == 0 and self._optimization_options["theta_optimization"]:
+            print("No thetas parameters turning off theta optimization.")
+        if self._optimization_options["opt_type"].lower() == "2step" and (
+            not self._optimization_options["orbital_optimization"]
+            or not self._optimization_options["theta_optimization"]
+        ):
+            if not self._optimization_options["orbital_optimization"]:
+                print("Orbital optimization not requested changing optimizer type to 1step.")
+                self._optimization_options["opt_type"] = "1step"
+            elif not self._optimization_options["theta_optimization"]:
+                print("theta optimization not requested changing optimizer type to 1step.")
+                self._optimization_options["opt_type"] = "1step"
+        if (
+            self._optimization_options["opt_type"].lower() == "1step"
+            and "1step_optimizer" not in self._optimization_options.keys()
+        ):
+            print(
+                "'1step_optimizer' was not specifed. Using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
+            )
+            self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
+        if self._optimization_options["theta_optimization"] and isinstance(self.QI.ansatz, QuantumCircuit):
+            if self._optimization_options["opt_type"].lower() == "1step" and self._optimization_options[
+                "1step_optimizer"
+            ].lower() not in ("cobyla", "cobyqa"):
+                raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
+            elif self._optimization_options["opt_type"].lower() == "2step" and self._optimization_options[
+                "theta_optimizer"
+            ].lower() not in ("cobyla", "cobyqa"):
+                raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
         print("### Parameters information:")
-        if orbital_optimization:
+        if self._optimization_options["orbital_optimization"]:
             print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {len(self.thetas)}")
+        if self._optimization_options["theta_optimization"]:
+            print("### Number theta: {len(self.thetas)}")
+        if self._optimization_options["opt_type"].lower() == "1step":
+            self._run_wf_optimization_1step()
+        elif self._optimization_options["opt_type"].lower() == "2step":
+            self._run_wf_optimization_1step()
+        else:
+            raise ValueError(
+                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."
+            )
+
+    def _run_wf_optimization_2step(
+        self,
+    ) -> None:
+        """Run two step optimization of wave function."""
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        for full_iter in range(0, int(maxiter)):
+        for full_iter in range(0, self._optimization_options["maxiter"]):
             full_start = time.time()
 
             # Do ansatz optimization
-            if not is_silent_subiterations:
+            if not self._optimization_options["is_silent_subiterations"]:
                 print("--------Ansatz optimization")
                 subheader = "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
-                if print_std:
+                if self._optimization_options["print_std"]:
                     subheader += " | Std(H)"
                 print(subheader)
 
@@ -932,11 +964,11 @@ class WaveFunctionCircuit:
             )
             optimizer = Optimizers(
                 energy_theta,
-                optimizer_name,
+                self._optimization_options["theta_optimizer"],
                 grad=gradient_theta,
-                maxiter=maxiter,
-                tol=tol,
-                is_silent=is_silent_subiterations,
+                maxiter=self._optimization_options["maxiter"],
+                tol=self._optimization_options["tol"],
+                is_silent=self._optimization_options["is_silent_subiterations"],
                 energy_eval_callback=lambda: self.num_energy_evals,
                 std_callback=(
                     (
@@ -948,7 +980,7 @@ class WaveFunctionCircuit:
                             )
                         )
                     )
-                    if print_std
+                    if self._optimization_options["print_std"]
                     else None
                 ),
             )
@@ -958,108 +990,80 @@ class WaveFunctionCircuit:
             )
             self.thetas = res.x.tolist()
 
-            if orbital_optimization and len(self.kappa) != 0:
-                if not is_silent_subiterations:
-                    print("--------Orbital optimization")
-                    subheader = "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
-                    if print_std:
-                        subheader += " | Std(H)"
-                    print(subheader)
+            if not self._optimization_options["is_silent_subiterations"]:
+                print("--------Orbital optimization")
+                subheader = "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
+                if self._optimization_options["print_std"]:
+                    subheader += " | Std(H)"
+                print(subheader)
 
-                energy_oo = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-                gradient_oo = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
+            energy_oo = partial(
+                self._calc_energy_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
+            gradient_oo = partial(
+                self._calc_gradient_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
 
-                optimizer = Optimizers(
-                    energy_oo,
-                    "l-bfgs-b",
-                    grad=gradient_oo,
-                    maxiter=maxiter,
-                    tol=tol,
-                    is_silent=is_silent_subiterations,
-                    energy_eval_callback=lambda: self.num_energy_evals,
-                    std_callback=(
-                        (
-                            lambda: self.QI.quantum_variance(
-                                hamiltonian_0i_0a(
-                                    self.h_mo, self.g_mo, self.num_inactive_orbs, self.num_active_orbs
-                                ).get_folded_operator(
-                                    self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs
-                                )
+            optimizer = Optimizers(
+                energy_oo,
+                self._optimization_options["orbital_optimizer"],
+                grad=gradient_oo,
+                maxiter=self._optimization_options["maxiter"],
+                tol=self._optimization_options["tol"],
+                is_silent=self._optimization_options["is_silent_subiterations"],
+                energy_eval_callback=lambda: self.num_energy_evals,
+                std_callback=(
+                    (
+                        lambda: self.QI.quantum_variance(
+                            hamiltonian_0i_0a(
+                                self.h_mo, self.g_mo, self.num_inactive_orbs, self.num_active_orbs
+                            ).get_folded_operator(
+                                self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs
                             )
                         )
-                        if print_std
-                        else None
-                    ),
-                )
-                res = optimizer.minimize([0.0] * len(self.kappa_idx))
-                for i in range(len(self.kappa)):
-                    self._kappa[i] = 0.0
-                    self._kappa_old[i] = 0.0
-            else:
-                # If there is no orbital optimization, then the algorithm is already converged.
-                e_new = res.fun
-                if orbital_optimization and len(self.kappa) == 0:
-                    print(
-                        "WARNING: No orbital optimization performed, because there is no non-redundant orbital parameters"
                     )
-                break
-
+                    if self._optimization_options["print_std"]
+                    else None
+                ),
+            )
+            res = optimizer.minimize([0.0] * len(self.kappa_idx))
+            for i in range(len(self.kappa)):
+                self._kappa[i] = 0.0
+                self._kappa_old[i] = 0.0
             e_new = res.fun
             time_str = f"{time.time() - full_start:7.2f}"  # type: ignore
             e_str = f"{e_new:3.12f}"
             print(
                 f"{str(full_iter + 1).center(11)} | {time_str.center(18)} | {e_str.center(27)} | {str(self.num_energy_evals).center(11)}"
             )  # type: ignore
-            if abs(e_new - e_old) < tol:
+            if abs(e_new - e_old) < self._optimization_options["tol"]:
                 break
             e_old = e_new
         self._energy_elec = e_new
 
-    def run_wf_optimization_1step(
+    def _run_wf_optimization_1step(
         self,
-        optimizer_name: str,
-        orbital_optimization: bool = False,
-        tol: float = 1e-10,
-        maxiter: int = 1000,
-        print_std: bool = False,
     ) -> None:
-        """Run one step optimization of wave function.
-
-        Args:
-            optimizer_name: Name of optimizer.
-            orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
-            maxiter: Maximum number of iterations.
-            print_std: Print standard deviation in sub-iteration headers.
-        """
-        if isinstance(self.QI.ansatz, QuantumCircuit) and optimizer_name.lower() not in ("cobyla", "cobyqa"):
-            raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
-        print("### Parameters information:")
-        if orbital_optimization:
-            print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {len(self.thetas)}")
-        if optimizer_name.lower() == "rotosolve":
-            if orbital_optimization and len(self.kappa) != 0:
-                raise ValueError(
-                    "Cannot use RotoSolve together with orbital optimization in the one-step solver."
-                )
-
+        """Run one step optimization of wave function."""
+        if (
+            self._optimization_options["1step_optimizer"].lower() == "rotosolve"
+            and self._optimization_options["orbital_optimization"]
+        ):
+            raise ValueError(
+                "Cannot use RotoSolve together with orbital optimization in the one-step solver."
+            )
         header = (
             "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
         )
-        if print_std:
+        if self._optimization_options["print_std"]:
             header += " | Std(H)"
         print(header)
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
                 energy = partial(
                     self._calc_energy_optimization,
                     theta_optimization=True,
@@ -1092,8 +1096,8 @@ class WaveFunctionCircuit:
                 theta_optimization=True,
                 kappa_optimization=False,
             )
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
@@ -1101,10 +1105,10 @@ class WaveFunctionCircuit:
             parameters = self.thetas
         optimizer = Optimizers(
             energy,
-            optimizer_name,
+            self._optimization_options["1step_optimizer"],
             grad=gradient,
-            maxiter=maxiter,
-            tol=tol,
+            maxiter=self._optimization_options["maxiter"],
+            tol=self._optimization_options["tol"],
             energy_eval_callback=lambda: self.num_energy_evals,
             std_callback=(
                 (
@@ -1116,15 +1120,16 @@ class WaveFunctionCircuit:
                         )
                     )
                 )
-                if print_std
+                if self._optimization_options["print_std"]
                 else None
             ),
         )
         res = optimizer.minimize(
             parameters, extra_options={"R": self.QI.grad_param_R, "param_names": self.QI.param_names}
         )
-        if orbital_optimization:
-            self.thetas = res.x[len(self.kappa) :].tolist()
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
+                self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0
                 self._kappa_old[i] = 0.0

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -80,7 +80,6 @@ class WaveFunctionCircuit:
         self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
         self.num_active_orbs = cas[1]
         self.num_active_spin_orbs = 2 * self.num_active_orbs
-        self.num_active_orbs = self.num_active_spin_orbs // 2
         self.num_virtual_orbs = (
             len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
         )

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -281,10 +281,10 @@ class WaveFunctionCircuit:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
-        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=np.int64)
-        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=np.int64)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
+        self.kappa_idx = np.array(kappa_idx, dtype=int)
+        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
+        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
         if ref_det == hf_det:
             # If the refernce determinant is just Hartree-Fock,
@@ -454,7 +454,7 @@ class WaveFunctionCircuit:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=np.float64)
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -487,7 +487,7 @@ class WaveFunctionCircuit:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -539,7 +539,7 @@ class WaveFunctionCircuit:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -603,7 +603,7 @@ class WaveFunctionCircuit:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -920,7 +920,7 @@ class WaveFunctionCircuit:
             and "1step_optimizer" not in self._optimization_options.keys()
         ):
             print(
-                "'1step_optimizer' was not specifed. Using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
+                f"'1step_optimizer' was not specifed. Using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
             )
             self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
         if self._optimization_options["theta_optimization"] and isinstance(self.QI.ansatz, QuantumCircuit):
@@ -940,7 +940,7 @@ class WaveFunctionCircuit:
         if self._optimization_options["opt_type"].lower() == "1step":
             self._run_wf_optimization_1step()
         elif self._optimization_options["opt_type"].lower() == "2step":
-            self._run_wf_optimization_1step()
+            self._run_wf_optimization_2step()
         else:
             raise ValueError(
                 f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -214,7 +214,7 @@ class WaveFunctionCircuit:
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excpected 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, expected 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -226,7 +226,7 @@ class WaveFunctionCircuit:
         kappa_no_activeactive_idx_dagger = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
-        # Loop over all q>p orb combinations
+        # Loop over all q>p orb combinations.
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
                 if p in self.inactive_idx and q in self.inactive_idx:
@@ -294,6 +294,8 @@ class WaveFunctionCircuit:
         self._g_mo = None
         self._energy_elec = None
         self._kappa = k.copy()
+        if isinstance(self._kappa, np.ndarray):
+            self._kappa = self._kappa.tolist()
         # Move current expansion point.
         self._c_mo = self.c_mo
         self._kappa_old = self.kappa
@@ -305,6 +307,7 @@ class WaveFunctionCircuit:
         Returns:
             Molecular orbital coefficients.
         """
+        # Construct anti-hermitian kappa matrix
         kappa_mat = np.zeros_like(self._c_mo)
         if len(self.kappa) != 0:
             # The MO transformation is calculated as a difference between current kappa and kappa old.
@@ -314,6 +317,7 @@ class WaveFunctionCircuit:
                 for kappa_val, kappa_old, (p, q) in zip(self.kappa, self._kappa_old, self.kappa_idx):
                     kappa_mat[p, q] = kappa_val - kappa_old
                     kappa_mat[q, p] = -(kappa_val - kappa_old)
+        # Apply orbital rotation unitary to MO coefficients
         return np.matmul(self._c_mo, scipy.linalg.expm(-kappa_mat))
 
     @property
@@ -417,12 +421,7 @@ class WaveFunctionCircuit:
 
     @property
     def rdm1(self) -> np.ndarray:
-        r"""Calculate one-electron reduced density matrix.
-
-        The trace condition is enforced:
-
-        .. math::
-            \sum_i\Gamma^{[1]}_{ii} = N_e
+        """Calculate one-electron reduced density matrix in the active space.
 
         Returns:
             One-electron reduced density matrix.
@@ -443,12 +442,7 @@ class WaveFunctionCircuit:
 
     @property
     def rdm2(self) -> np.ndarray:
-        r"""Calculate two-electron reduced density matrix.
-
-        The trace condition is enforced:
-
-        .. math::
-            \sum_{ij}\Gamma^{[2]}_{iijj} = N_e(N_e-1)
+        """Calculate two-electron reduced density matrix in the active space.
 
         Returns:
             Two-electron reduced density matrix.
@@ -493,12 +487,9 @@ class WaveFunctionCircuit:
 
     @property
     def rdm3(self) -> np.ndarray:
-        r"""Calculate three-electron reduced density matrix.
+        """Calculate three-electron reduced density matrix in the active space.
 
-        The trace condition is enforced:
-
-        .. math::
-            \sum_{ijk}\Gamma^{[3]}_{iijjkk} = N_e(N_e-1)(N_e-2)
+        Currently not utilizing the full symmetry.
 
         Returns:
             Three-electron reduced density matrix.
@@ -555,12 +546,9 @@ class WaveFunctionCircuit:
 
     @property
     def rdm4(self) -> np.ndarray:
-        r"""Calculate four-electron reduced density matrix.
+        """Calculate four-electron reduced density matrix in the active space.
 
-        The trace condition is enforced:
-
-        .. math::
-            \sum_{ijkl}\Gamma^{[4]}_{iijjkkll} = N_e(N_e-1)(N_e-2)(N_e-3)
+        Currently not utilizing the full symmetry.
 
         Returns:
             Four-electron reduced density matrix.
@@ -877,7 +865,7 @@ class WaveFunctionCircuit:
                 tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations, print_std
             )
         else:
-            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} expected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
@@ -1117,7 +1105,6 @@ class WaveFunctionCircuit:
         Returns:
             Electronic gradient.
         """
-        num_kappa = 0
         gradient = np.zeros(len(parameters))
         num_kappa = 0
         if kappa_optimization:

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -276,6 +276,8 @@ class WaveFunctionCircuit:
             (self.num_active_elec_alpha, self.num_active_elec_beta),
             ref_det=self.ref_det,
         )
+        # Save for uses outside WF class.
+        self._ref_det = ref_det
 
     @property
     def kappa(self) -> list[float]:

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -42,6 +42,20 @@ class WaveFunctionCircuit:
     ) -> None:
         """Initialize circuit based UPS wave function.
 
+        Wavefunction Options:
+            * do_pp [bool]: Make perfect-pairing reference determinant.
+                            Will also reorder the orbitalers to match the determinant.
+                            (default: False)
+            * include_active_kappa [bool]: Include active-active orbital rotations.
+                                           (default: True)
+            * resolve_unpaired_idx [str]: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                          'both', include spatial index in both occ and unocc idx list.
+                                          'occ', include spatial index only in occ idx list.
+                                          'unocc', include spatial index only in unocc idx list.
+                                          (default: 'both')
+            * reference_determinant [str]: Specify a reference determinant for the active space part.
+                                          1 specifying occupied orbital and 0 specifying unoccupied orbital.
+
         Args:
             active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
                  orbitals are counted in spatial basis.

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -1,7 +1,5 @@
-import copy
 import time
 from functools import partial
-from typing import Any
 
 import numpy as np
 import pyscf
@@ -38,23 +36,12 @@ class WaveFunctionCircuit:
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         quantum_interface: QuantumInterface,
-        wavefunction_options: dict[str, Any] | None = None,
+        reference_determinant: str | None = None,
+        include_active_kappa: bool = True,
+        resolve_unpaired_idx: str = "both",
+        do_pp: bool = False,
     ) -> None:
         """Initialize circuit based UPS wave function.
-
-        Wavefunction Options:
-            * do_pp [bool]: Make perfect-pairing reference determinant.
-                            Will also reorder the orbitalers to match the determinant.
-                            (default: False)
-            * include_active_kappa [bool]: Include active-active orbital rotations.
-                                           (default: True)
-            * resolve_unpaired_idx [str]: Specify how to resolve spatial index with respect to occupation of reference determinant.
-                                          'both', include spatial index in both occ and unocc idx list.
-                                          'occ', include spatial index only in occ idx list.
-                                          'unocc', include spatial index only in unocc idx list.
-                                          (default: 'both')
-            * reference_determinant [str]: Specify a reference determinant for the active space part.
-                                          1 specifying occupied orbital and 0 specifying unoccupied orbital.
 
         Args:
             active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
@@ -62,26 +49,15 @@ class WaveFunctionCircuit:
             mo_coeffs: Initial orbital coefficients.
             integral_generator: Integral generator object.
             quantum_interface: QuantumInterface.
-            wavefunction_options: Wavefunction options.
+            reference_determinant: Specify a reference determinant for the active space part.
+                                   1 specifying occupied orbital and 0 specifying unoccupied orbital.
+            include_active_kappa: Include active-active orbital rotations.
+            resolve_unpaired_idx: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                  'both', include spatial index in both occ and unocc idx list.
+                                  'occ', include spatial index only in occ idx list.
+                                  'unocc', include spatial index only in unocc idx list.
+            do_pp: Make perfect-pairing reference determinant. Will also reorder the orbitalers to match the determinant.
         """
-        if wavefunction_options is None:
-            wavefunction_options = {}
-        self.wavefunction_options = copy.deepcopy(wavefunction_options)
-        valid_options = (
-            "do_pp",
-            "resolve_unpaired_idx",
-            "include_active_kappa",
-            "reference_determinant",
-        )
-        for option in wavefunction_options:
-            if option not in valid_options:
-                raise ValueError(
-                    f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
-                )
-        # Default options
-        self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
-        self.wavefunction_options.setdefault("include_active_kappa", True)
-        self.wavefunction_options.setdefault("do_pp", False)
         if len(active_space) != 2:
             raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
         if isinstance(active_space[0], int):
@@ -128,12 +104,9 @@ class WaveFunctionCircuit:
         self.num_energy_evals = 0
         self._c_mo = mo_coeffs
         # Reference wave function
-        self._pp = self.wavefunction_options["do_pp"]
-        if self.wavefunction_options["do_pp"]:
-            if "reference_determinant" in self.wavefunction_options.keys():
-                raise ValueError(
-                    "Both 'do_pp' and 'reference_determinant' are requested in 'wavefunction_options'."
-                )
+        if do_pp:
+            if reference_determinant is not None:
+                raise ValueError("Both 'do_pp' and 'reference_determinant' are requested.")
             if self.num_active_elec_alpha != self.num_active_elec_beta:
                 raise ValueError(
                     "perfect-pairing is only defined for equal number of alpha and beta electrons."
@@ -173,15 +146,15 @@ class WaveFunctionCircuit:
             self._c_mo = pp_mo_coeffs
 
             ref_det = pp_det
-        elif "reference_determinant" in self.wavefunction_options.keys():
-            ref_det = self.wavefunction_options["reference_determinant"]
+        elif reference_determinant is not None:
+            ref_det = reference_determinant
             if len(ref_det) != self.num_active_spin_orbs:
                 raise ValueError(
                     f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
                 )
             ref_alpha = 0
             ref_beta = 0
-            for i, idx in ref_det:
+            for i, idx in enumerate(ref_det):
                 if i % 2 == 0 and idx == "1":
                     ref_alpha += 1
                 elif idx == "1":
@@ -233,16 +206,16 @@ class WaveFunctionCircuit:
                 self.active_occ_idx.append(orb_idx)
             elif ref_det[2 * i] == "0" and ref_det[2 * i + 1] == "0":
                 self.active_unocc_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "both":
+            elif resolve_unpaired_idx == "both":
                 self.active_occ_idx.append(orb_idx)
                 self.active_unocc_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
+            elif resolve_unpaired_idx == "occ":
                 self.active_occ_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
+            elif resolve_unpaired_idx == "unocc":
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, excpected 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excpected 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -261,7 +234,7 @@ class WaveFunctionCircuit:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
                     continue
-                if not self.wavefunction_options["include_active_kappa"]:
+                if not include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
                         continue
                 if not (p in self.active_idx and q in self.active_idx):
@@ -846,121 +819,89 @@ class WaveFunctionCircuit:
 
     def run_wf_optimization(
         self,
-        orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
-        optimization_options: dict[str, Any] | None = None,
+        orbital_optimization: bool = False,
+        theta_optimization: bool = True,
+        one_step_optimizer: str = "BFGS",
+        theta_optimizer: str = "BFGS",
+        orbital_optimizer: str = "BFGS",
+        opt_type: str = "1step",
+        is_silent_subiterations: bool = False,
+        print_std: bool = False,
     ) -> None:
         """Run variational optimization of wavefunction.
 
-        Optimization options:
-            * theta_optimization [bool]: Perform theta optimization.
-                                         (default: True)
-            * theta_optimizer [str]: Optimizer used for theta optimization.
-                                     (default: BFGS)
-            * orbital_optimizer [str]: Optimizer used for orbital optimization.
-                                     (default: BFGS)
-            * 1step_optimizer [str]: Optimizer used for 1step optimizer.
-                                     (fallback: copy theta_optimizer)
-            * opt_type [str]: Optimization type, can be '1step' or '2step'.
-                              (default: 1step)
-            * is_silent_subiterations [bool]: Silence sub iterations in 2step.
-                                              (default: False)
-            * print_std [bool]: Print standard deviation of the electronic Hamiltonian during optimization.
-                                (default: False)
-
         Args:
-            orbital_optimization: Perform orbital optimization.
             tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            optimization_options: Additional optimization options.
+            orbital_optimization: Perform orbital optimization.
+            theta_optimization: Perform theta optimization.
+            one_step_optimizer: Optimizer used for 1step optimizer.
+            theta_optimizer: Optimizer used for theta optimization in 2step optimizer.
+            orbital_optimizer: Optimizer used for orbital optimization in 2step optimizer.
+            opt_type: Optimization type, can be '1step' or '2step'.
+            is_silent_subiterations: Silence sub iterations in 2step.
+            print_std: Print standard deviation of the electronic Hamiltonian during optimization.
         """
-        if optimization_options is None:
-            optimization_options = {}
-        self._optimization_options = copy.deepcopy(optimization_options)
-        valid_options = (
-            "theta_optimization",
-            "theta_optimizer",
-            "orbital_optimizer",
-            "opt_type",
-            "is_silent_subiterations",
-            "1step_optimizer",
-            "print_std",
-        )
-        for option in self._optimization_options:
-            if option not in valid_options:
-                raise ValueError(
-                    f"Got unknown option for optimization, {option}. Valid options are: {valid_options}"
-                )
-        self._optimization_options["tol"] = tol
-        self._optimization_options["maxiter"] = int(maxiter)
-        self._optimization_options["orbital_optimization"] = orbital_optimization
-        self._optimization_options.setdefault("theta_optimization", True)
-        self._optimization_options.setdefault("theta_optimizer", "BFGS")
-        self._optimization_options.setdefault("orbital_optimizer", "BFGS")
-        self._optimization_options.setdefault("opt_type", "1step")
-        self._optimization_options.setdefault("is_silent_subiterations", False)
-        self._optimization_options.setdefault("print_std", False)
-        if len(self.kappa) == 0 and self._optimization_options["orbital_optimization"]:
+        if len(self.kappa) == 0 and orbital_optimization:
             print("No kappa parameters turning off orbital optimization.")
-        if len(self.thetas) == 0 and self._optimization_options["theta_optimization"]:
+            orbital_optimization = False
+        if len(self.thetas) == 0 and theta_optimization:
             print("No thetas parameters turning off theta optimization.")
-        if self._optimization_options["opt_type"].lower() == "2step" and (
-            not self._optimization_options["orbital_optimization"]
-            or not self._optimization_options["theta_optimization"]
-        ):
-            if not self._optimization_options["orbital_optimization"]:
+            theta_optimization = False
+        if opt_type.lower() == "2step" and (not orbital_optimization or not theta_optimization):
+            if not orbital_optimization:
                 print("Orbital optimization not requested changing optimizer type to 1step.")
-                self._optimization_options["opt_type"] = "1step"
-            elif not self._optimization_options["theta_optimization"]:
+                opt_type = "1step"
+            elif not theta_optimization:
                 print("theta optimization not requested changing optimizer type to 1step.")
-                self._optimization_options["opt_type"] = "1step"
-        if (
-            self._optimization_options["opt_type"].lower() == "1step"
-            and "1step_optimizer" not in self._optimization_options.keys()
-        ):
-            print(
-                f"'1step_optimizer' was not specifed. Using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
-            )
-            self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
-        if self._optimization_options["theta_optimization"] and isinstance(self.QI.ansatz, QuantumCircuit):
-            if self._optimization_options["opt_type"].lower() == "1step" and self._optimization_options[
-                "1step_optimizer"
-            ].lower() not in ("cobyla", "cobyqa"):
+                opt_type = "1step"
+        if theta_optimization and isinstance(self.QI.ansatz, QuantumCircuit):
+            if opt_type.lower() == "1step" and one_step_optimizer.lower() not in ("cobyla", "cobyqa"):
                 raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
-            elif self._optimization_options["opt_type"].lower() == "2step" and self._optimization_options[
-                "theta_optimizer"
-            ].lower() not in ("cobyla", "cobyqa"):
+            elif opt_type.lower() == "2step" and theta_optimizer.lower() not in ("cobyla", "cobyqa"):
                 raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
         print("### Parameters information:")
-        if self._optimization_options["orbital_optimization"]:
+        if orbital_optimization:
             print(f"### Number kappa: {len(self.kappa)}")
-        if self._optimization_options["theta_optimization"]:
+        if theta_optimization:
             print("### Number theta: {len(self.thetas)}")
-        if self._optimization_options["opt_type"].lower() == "1step":
-            self._run_wf_optimization_1step()
-        elif self._optimization_options["opt_type"].lower() == "2step":
-            self._run_wf_optimization_2step()
-        else:
-            raise ValueError(
-                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."
+        if opt_type.lower() == "1step":
+            self._run_wf_optimization_1step(
+                tol, maxiter, orbital_optimization, theta_optimization, one_step_optimizer, print_std
             )
+        elif opt_type.lower() == "2step":
+            self._run_wf_optimization_2step(
+                tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations, print_std
+            )
+        else:
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
+        tol: float,
+        maxiter: int,
+        theta_optimizer: str,
+        orbital_optimizer: str,
+        is_silent_subiterations: bool,
+        print_std: bool,
     ) -> None:
-        """Run two step optimization of wave function."""
+        """Run two step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        for full_iter in range(0, self._optimization_options["maxiter"]):
+        for full_iter in range(0, maxiter):
             full_start = time.time()
-
             # Do ansatz optimization
-            if not self._optimization_options["is_silent_subiterations"]:
+            if not is_silent_subiterations:
                 print("--------Ansatz optimization")
                 subheader = "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
-                if self._optimization_options["print_std"]:
+                if print_std:
                     subheader += " | Std(H)"
                 print(subheader)
 
@@ -976,11 +917,11 @@ class WaveFunctionCircuit:
             )
             optimizer = Optimizers(
                 energy_theta,
-                self._optimization_options["theta_optimizer"],
+                theta_optimizer,
                 grad=gradient_theta,
-                maxiter=self._optimization_options["maxiter"],
-                tol=self._optimization_options["tol"],
-                is_silent=self._optimization_options["is_silent_subiterations"],
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
                 energy_eval_callback=lambda: self.num_energy_evals,
                 std_callback=(
                     (
@@ -992,7 +933,7 @@ class WaveFunctionCircuit:
                             )
                         )
                     )
-                    if self._optimization_options["print_std"]
+                    if print_std
                     else None
                 ),
             )
@@ -1002,13 +943,12 @@ class WaveFunctionCircuit:
             )
             self.thetas = res.x.tolist()
 
-            if not self._optimization_options["is_silent_subiterations"]:
+            if not is_silent_subiterations:
                 print("--------Orbital optimization")
                 subheader = "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
-                if self._optimization_options["print_std"]:
+                if print_std:
                     subheader += " | Std(H)"
                 print(subheader)
-
             energy_oo = partial(
                 self._calc_energy_optimization,
                 theta_optimization=False,
@@ -1022,11 +962,11 @@ class WaveFunctionCircuit:
 
             optimizer = Optimizers(
                 energy_oo,
-                self._optimization_options["orbital_optimizer"],
+                orbital_optimizer,
                 grad=gradient_oo,
-                maxiter=self._optimization_options["maxiter"],
-                tol=self._optimization_options["tol"],
-                is_silent=self._optimization_options["is_silent_subiterations"],
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
                 energy_eval_callback=lambda: self.num_energy_evals,
                 std_callback=(
                     (
@@ -1038,7 +978,7 @@ class WaveFunctionCircuit:
                             )
                         )
                     )
-                    if self._optimization_options["print_std"]
+                    if print_std
                     else None
                 ),
             )
@@ -1052,64 +992,47 @@ class WaveFunctionCircuit:
             print(
                 f"{str(full_iter + 1).center(11)} | {time_str.center(18)} | {e_str.center(27)} | {str(self.num_energy_evals).center(11)}"
             )  # type: ignore
-            if abs(e_new - e_old) < self._optimization_options["tol"]:
+            if abs(e_new - e_old) < tol:
                 break
             e_old = e_new
         self._energy_elec = e_new
 
     def _run_wf_optimization_1step(
         self,
+        tol: float,
+        maxiter: int,
+        orbital_optimization: bool,
+        theta_optimization: bool,
+        one_step_optimizer: str,
+        print_std: bool,
     ) -> None:
-        """Run one step optimization of wave function."""
-        if (
-            self._optimization_options["1step_optimizer"].lower() == "rotosolve"
-            and self._optimization_options["orbital_optimization"]
-        ):
+        """Run one step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
+        if one_step_optimizer.lower() == "rotosolve" and orbital_optimization:
             raise ValueError(
                 "Cannot use RotoSolve together with orbital optimization in the one-step solver."
             )
         header = (
             "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
         )
-        if self._optimization_options["print_std"]:
+        if print_std:
             header += " | Std(H)"
         print(header)
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-            else:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-        else:
-            energy = partial(
-                self._calc_energy_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-            gradient = partial(
-                self._calc_gradient_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
+        energy = partial(
+            self._calc_energy_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        gradient = partial(
+            self._calc_gradient_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        if orbital_optimization:
+            if theta_optimization:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
@@ -1117,10 +1040,10 @@ class WaveFunctionCircuit:
             parameters = self.thetas
         optimizer = Optimizers(
             energy,
-            self._optimization_options["1step_optimizer"],
+            one_step_optimizer,
             grad=gradient,
-            maxiter=self._optimization_options["maxiter"],
-            tol=self._optimization_options["tol"],
+            maxiter=maxiter,
+            tol=tol,
             energy_eval_callback=lambda: self.num_energy_evals,
             std_callback=(
                 (
@@ -1132,15 +1055,15 @@ class WaveFunctionCircuit:
                         )
                     )
                 )
-                if self._optimization_options["print_std"]
+                if print_std
                 else None
             ),
         )
         res = optimizer.minimize(
             parameters, extra_options={"R": self.QI.grad_param_R, "param_names": self.QI.param_names}
         )
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
+        if orbital_optimization:
+            if theta_optimization:
                 self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0

--- a/slowquant/qiskit_interface/circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction.py
@@ -88,7 +88,7 @@ class WaveFunctionCircuit:
             if active_space[0] % 2 == 0:
                 cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
             else:
-                # Uneven number of electrons mean one electron must be unpaired.
+                # Odd number of electrons mean one electron must be unpaired.
                 cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
         else:
             cas = ((active_space[0][0], active_space[0][1]), active_space[1])
@@ -172,7 +172,6 @@ class WaveFunctionCircuit:
             # Note self._c_mo is set previously but overwritten here.
             self._c_mo = pp_mo_coeffs
 
-            # Assign weight to reference
             ref_det = pp_det
         elif "reference_determinant" in self.wavefunction_options.keys():
             ref_det = self.wavefunction_options["reference_determinant"]
@@ -255,10 +254,9 @@ class WaveFunctionCircuit:
         kappa_no_activeactive_idx_dagger = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
-        # Loop over all q>p orb combinations and find redundant kappas
+        # Loop over all q>p orb combinations
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
-                # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:

--- a/slowquant/qiskit_interface/circuit_wavefunction_from_ups.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction_from_ups.py
@@ -44,16 +44,13 @@ def circuit_wavefunction_from_ups(
     Returns:
         Circuit wavefunction.
     """
-    ansatz_options = None
-    if hasattr(ups_wf, "_pp") and ups_wf._pp:
-        ansatz_options = {"do_pp": True}
     QI = QuantumInterface(
         primitive=primitive,
         ansatz=ups_wf.ups_layout,
         mapper=mapper,
         ISA=ISA,
         pass_manager_options=pass_manager_options,
-        ansatz_options=ansatz_options,
+        ansatz_options=None,
         shots=shots,
         max_shots_per_run=max_shots_per_run,
         do_M_mitigation=do_M_mitigation,
@@ -63,23 +60,25 @@ def circuit_wavefunction_from_ups(
     )
     if isinstance(ups_wf, WaveFunctionUPS):
         wf = WaveFunctionCircuit(
-            (ups_wf.num_active_elec, ups_wf.num_active_orbs),
+            ((ups_wf.num_active_elec_alpha, ups_wf.num_active_elec_beta), ups_wf.num_active_orbs),
             ups_wf.c_mo,
             ups_wf.int_gen.int_obj,
             QI,
-            include_active_kappa=ups_wf._include_active_kappa,
-            force_no_pp_mos=True,  # passed MOs are already in pp form.
+            wavefunction_options={
+                "include_active_kappa": ups_wf._include_active_kappa,
+                "reference_determinant": ups_wf._ref_det,
+            },
         )
         wf.thetas = ups_wf.thetas
         return wf
     elif isinstance(ups_wf, WaveFunctionSAUPS):
         sawf = WaveFunctionSACircuit(
-            (ups_wf.num_active_elec, ups_wf.num_active_orbs),
+            ((ups_wf.num_active_elec_alpha, ups_wf.num_active_elec_beta), ups_wf.num_active_orbs),
             ups_wf.c_mo,
             ups_wf.int_gen.int_obj,
             ups_wf._states,
             QI,
-            include_active_kappa=ups_wf._include_active_kappa,
+            wavefunction_options={"include_active_kappa": ups_wf._include_active_kappa},
         )
         sawf.thetas = ups_wf.thetas
         return sawf

--- a/slowquant/qiskit_interface/circuit_wavefunction_from_ups.py
+++ b/slowquant/qiskit_interface/circuit_wavefunction_from_ups.py
@@ -64,10 +64,9 @@ def circuit_wavefunction_from_ups(
             ups_wf.c_mo,
             ups_wf.int_gen.int_obj,
             QI,
-            wavefunction_options={
-                "include_active_kappa": ups_wf._include_active_kappa,
-                "reference_determinant": ups_wf._ref_det,
-            },
+            reference_determinant=ups_wf._ref_det,
+            include_active_kappa=ups_wf._include_active_kappa,
+            resolve_unpaired_idx=ups_wf._resolve_unpaired_idx,
         )
         wf.thetas = ups_wf.thetas
         return wf
@@ -78,7 +77,8 @@ def circuit_wavefunction_from_ups(
             ups_wf.int_gen.int_obj,
             ups_wf._states,
             QI,
-            wavefunction_options={"include_active_kappa": ups_wf._include_active_kappa},
+            include_active_kappa=ups_wf._include_active_kappa,
+            resolve_unpaired_idx=ups_wf._resolve_unpaired_idx,
         )
         sawf.thetas = ups_wf.thetas
         return sawf

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -125,7 +125,7 @@ class QuantumInterface:
         self.total_device_calls = 0
         self.total_paulis_evaluated = 0
         self.ansatz_options = ansatz_options
-        self._pass_manager: PassManager = None
+        self._pass_manager: PassManager | None = None
         self.saver: dict[int, Clique] = {}
         self._save_paulis = True  # hard switch to stop using Pauli saving (debugging tool).
         self._do_cliques = True  # hard switch to stop using QWC (debugging tool).
@@ -139,6 +139,7 @@ class QuantumInterface:
         unocc_spin_idx: list[int],
         num_orbs: int,
         num_elec: tuple[int, int],
+        ref_det: str | None = None,
     ) -> None:
         """Construct qiskit circuit.
 
@@ -149,6 +150,7 @@ class QuantumInterface:
             unocc_spin_idx: Weakly occupied spin orbital indices.
             num_orbs: Number of spatial orbitals.
             num_elec: Number of electrons (alpha, beta).
+            ref_det: Reference determinant.
         """
         self.num_orbs = num_orbs
         self.num_spin_orbs = 2 * num_orbs
@@ -166,36 +168,8 @@ class QuantumInterface:
             self.state_circuit: QuantumCircuit = QuantumCircuit(
                 self.ansatz.num_qubits
             )  # empty state as custom circuit is passed
-        elif "do_pp" in self.ansatz_options.keys() and self.ansatz_options["do_pp"]:
-            # HF in pp-tUPS ordering
-            if not isinstance(self.mapper, JordanWignerMapper):
-                raise ValueError(f"pp-tUPS only implemented for JW mapper, got: {type(self.mapper)}")
-            # Obtain pp determinant
-            pp_det = ""
-            spin_orb = 0
-            elec_count = self.num_elec[0] + self.num_elec[1]
-            while spin_orb < self.num_spin_orbs:
-                if (
-                    elec_count >= 2
-                    and (self.num_spin_orbs - spin_orb) >= 4
-                    and elec_count <= (self.num_spin_orbs - spin_orb - 2)
-                ):
-                    pp_det += "1100"
-                    elec_count -= 2
-                    spin_orb += 4
-                elif elec_count == 0:
-                    pp_det += "0"
-                    spin_orb += 1
-                elif elec_count != 0:
-                    pp_det += "1"
-                    spin_orb += 1
-                    elec_count -= 1
-            print("State preparation: perfect-pairing determinant found as:", pp_det)
-            if len(pp_det) != self.num_spin_orbs or pp_det.count("1") != (
-                self.num_elec[0] + self.num_elec[1]
-            ):
-                raise ValueError("Perfect pairing determinant violates orbital or electron numbers")
-            self.state_circuit = get_determinant_reference(pp_det, self.num_orbs, self.mapper)
+        elif ref_det is not None:
+            self.state_circuit = get_determinant_reference(ref_det, self.num_orbs, self.mapper)
         else:
             self.state_circuit = HartreeFock(num_orbs, num_elec, self.mapper)
         self.num_qubits = self.state_circuit.num_qubits
@@ -212,18 +186,17 @@ class QuantumInterface:
             ups_layout = UpsStructure()
             if self.ansatz.lower() in ("fucc", "fuccpd", "fuccd", "fuccsd", "ksafupccgsd"):
                 if self.ansatz.lower() == "fuccpd":
-                    self.ansatz_options["pD"] = True
+                    self.ansatz_options["excitations"].append("pD")
                 elif self.ansatz.lower() == "fuccd":
-                    self.ansatz_options["D"] = True
+                    self.ansatz_options["excitations"].append("D")
                 elif self.ansatz.lower() == "fuccsd":
-                    self.ansatz_options["S"] = True
-                    self.ansatz_options["D"] = True
+                    self.ansatz_options["excitations"].append("S")
+                    self.ansatz_options["excitations"].append("D")
                 elif self.ansatz.lower() == "ksafupccgsd":
-                    self.ansatz_options["SAGS"] = True
-                    self.ansatz_options["GpD"] = True
-                if "n_layers" not in self.ansatz_options.keys():
-                    # default option
-                    self.ansatz_options["n_layers"] = 1
+                    self.ansatz_options["excitations"].append("SAGS")
+                    self.ansatz_options["excitations"].append("GpD")
+                # Default options
+                self.ansatz_options.setdefault("n_layers", 1)
                 ups_layout.create_fUCC(
                     occ_idx,
                     unocc_idx,
@@ -243,12 +216,11 @@ class QuantumInterface:
                 ups_layout.create_tiled(self.num_orbs, self.ansatz_options)
             elif self.ansatz.lower() in ("sdsfuccsd", "ksasdsfupccgsd"):
                 if self.ansatz.lower() == "sdsfuccsd":
-                    self.ansatz_options["D"] = True
+                    self.ansatz_options["excitations"].append("D")
                 elif self.ansatz.lower() == "ksasdsfupccgsd":
-                    self.ansatz_options["GpD"] = True
-                if "n_layers" not in self.ansatz_options.keys():
-                    # default option
-                    self.ansatz_options["n_layers"] = 1
+                    self.ansatz_options["excitations"].append("GpD")
+                # Default options
+                self.ansatz_options.setdefault("n_layers", 1)
                 ups_layout.create_SDSfUCC(
                     occ_idx,
                     unocc_idx,
@@ -888,9 +860,9 @@ class QuantumInterface:
                             del state_corr.data[idx]
                     if self.ISA:
                         # Translate and optimize
-                        state_corr = self._pass_manager.optimization.run(
-                            self._pass_manager.translation.run(state_corr)
-                        )  # type: ignore
+                        state_corr = self._pass_manager.optimization.run(  # type: ignore
+                            self._pass_manager.translation.run(state_corr)  # type: ignore
+                        )
                     # Negate
                     if circuit.layout is not None:
                         circuit_M = circuit.compose(

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -185,6 +185,7 @@ class QuantumInterface:
         elif isinstance(self.ansatz, str):
             ups_layout = UpsStructure()
             if self.ansatz.lower() in ("fucc", "fuccpd", "fuccd", "fuccsd", "ksafupccgsd"):
+                self.ansatz_options.setdefault("excitations", [])
                 if self.ansatz.lower() == "fuccpd":
                     self.ansatz_options["excitations"].append("pD")
                 elif self.ansatz.lower() == "fuccd":
@@ -215,6 +216,7 @@ class QuantumInterface:
                     self.ansatz_options["do_qnp"] = True
                 ups_layout.create_tiled(self.num_orbs, self.ansatz_options)
             elif self.ansatz.lower() in ("sdsfuccsd", "ksasdsfupccgsd"):
+                self.ansatz_options.setdefault("excitations", [])
                 if self.ansatz.lower() == "sdsfuccsd":
                     self.ansatz_options["excitations"].append("D")
                 elif self.ansatz.lower() == "ksasdsfupccgsd":

--- a/slowquant/qiskit_interface/linear_response/lr_baseclass.py
+++ b/slowquant/qiskit_interface/linear_response/lr_baseclass.py
@@ -35,6 +35,10 @@ class quantumLRBaseClass:
             excitations: Which excitation orders to include in response.
         """
         self.wf = wf
+        for i in range(self.wf.num_active_orbs):
+            if self.wf._ref_det[2 * i] != self.wf._ref_det[2 * i + 1]:
+                print("WARNING: Linear response is not tested for open-shell reference determinants.")
+                break
         # Create operators
         self.H_0i_0a = hamiltonian_0i_0a(wf.h_mo, wf.g_mo, wf.num_inactive_orbs, wf.num_active_orbs)
         self.H_1i_1a = hamiltonian_1i_1a(

--- a/slowquant/qiskit_interface/operators_circuits.py
+++ b/slowquant/qiskit_interface/operators_circuits.py
@@ -359,7 +359,7 @@ def _single_excitation_trotter(
     for pauli, fac in zip(ops, factors):
         qc.append(
             PauliEvolutionGate(Pauli(pauli), fac * theta),
-            np.linspace(0, num_qubits - 1, num_qubits, dtype=np.int64).tolist(),
+            np.linspace(0, num_qubits - 1, num_qubits, dtype=int).tolist(),
         )
     return qc
 
@@ -407,7 +407,7 @@ def _double_excitation_trotter(
     for pauli, fac in zip(ops, factors):
         qc.append(
             PauliEvolutionGate(Pauli(pauli), fac * theta),
-            np.linspace(0, num_qubits - 1, num_qubits, dtype=np.int64).tolist(),
+            np.linspace(0, num_qubits - 1, num_qubits, dtype=int).tolist(),
         )
     return qc
 

--- a/slowquant/qiskit_interface/operators_circuits.py
+++ b/slowquant/qiskit_interface/operators_circuits.py
@@ -359,7 +359,7 @@ def _single_excitation_trotter(
     for pauli, fac in zip(ops, factors):
         qc.append(
             PauliEvolutionGate(Pauli(pauli), fac * theta),
-            np.linspace(0, num_qubits - 1, num_qubits, dtype=int).tolist(),
+            np.linspace(0, num_qubits - 1, num_qubits, dtype=np.int64).tolist(),
         )
     return qc
 
@@ -407,7 +407,7 @@ def _double_excitation_trotter(
     for pauli, fac in zip(ops, factors):
         qc.append(
             PauliEvolutionGate(Pauli(pauli), fac * theta),
-            np.linspace(0, num_qubits - 1, num_qubits, dtype=int).tolist(),
+            np.linspace(0, num_qubits - 1, num_qubits, dtype=np.int64).tolist(),
         )
     return qc
 

--- a/slowquant/qiskit_interface/sa_circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_circuit_wavefunction.py
@@ -79,7 +79,6 @@ class WaveFunctionSACircuit:
         self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
         self.num_active_orbs = cas[1]
         self.num_active_spin_orbs = 2 * self.num_active_orbs
-        self.num_active_orbs = self.num_active_spin_orbs // 2
         self.num_virtual_orbs = (
             len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
         )

--- a/slowquant/qiskit_interface/sa_circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_circuit_wavefunction.py
@@ -809,7 +809,7 @@ class WaveFunctionSACircuit:
             transition_property[i] = self._state_ci_coeffs[:, i + 1] @ state_op @ self._state_ci_coeffs[:, 0]
         return transition_property
 
-    def get_oscillator_strenghts(self) -> np.ndarray:
+    def get_oscillator_strengths(self) -> np.ndarray:
         r"""Get oscillator strengths between ground state and excited states.
 
         .. math::

--- a/slowquant/qiskit_interface/sa_circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_circuit_wavefunction.py
@@ -234,6 +234,8 @@ class WaveFunctionSACircuit:
         self._sa_energy = None
         self._state_energies = None
         self._kappa = k.copy()
+        if isinstance(self._kappa, np.ndarray):
+            self._kappa = self._kappa.tolist()
         # Move current expansion point.
         self._c_mo = self.c_mo
         self._kappa_old = self.kappa
@@ -245,6 +247,7 @@ class WaveFunctionSACircuit:
         Returns:
             Molecular orbital coefficients.
         """
+        # Construct anti-hermitian kappa matrix
         kappa_mat = np.zeros_like(self._c_mo)
         if len(self.kappa) != 0:
             # The MO transformation is calculated as a difference between current kappa and kappa old.
@@ -254,6 +257,7 @@ class WaveFunctionSACircuit:
                 for kappa_val, kappa_old, (p, q) in zip(self.kappa, self._kappa_old, self.kappa_idx):
                     kappa_mat[p, q] = kappa_val - kappa_old
                     kappa_mat[q, p] = -(kappa_val - kappa_old)
+        # Apply orbital rotation unitary to MO coefficients
         return np.matmul(self._c_mo, scipy.linalg.expm(-kappa_mat))
 
     @property
@@ -299,7 +303,6 @@ class WaveFunctionSACircuit:
         self._sa_energy = None
         self._state_energies = None
         self._state_ci_coeffs = None
-        self._ci_coeffs = None
         self.QI.parameters = parameters
 
     def change_primitive(self, primitive: BaseSamplerV1 | BaseSamplerV2, verbose: bool = True) -> None:
@@ -356,12 +359,7 @@ class WaveFunctionSACircuit:
 
     @property
     def rdm1(self) -> np.ndarray:
-        r"""Calculate one-electron reduced density matrix.
-
-        The trace condition is enforced:
-
-        .. math::
-            \sum_i\Gamma^{[1]}_{ii} = N_e
+        """Calculate one-electron reduced density matrix in the active space.
 
         Returns:
             One-electron reduced density matrix.
@@ -369,9 +367,9 @@ class WaveFunctionSACircuit:
         if self._rdm1 is None:
             self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     rdm1_op = Epq(p, q).get_folded_operator(
                         self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs
                     )
@@ -379,18 +377,13 @@ class WaveFunctionSACircuit:
                     for coeffs, csf in zip(self.states[0], self.states[1]):
                         val += self.QI.quantum_expectation_value_csfs((coeffs, csf), rdm1_op, (coeffs, csf))
                     val = val / self.num_states
-                    self._rdm1[p_idx, q_idx] = val  # type: ignore [index]
-                    self._rdm1[q_idx, p_idx] = val  # type: ignore [index]
+                    self._rdm1[p_, q_] = val  # type: ignore [index]
+                    self._rdm1[q_, p_] = val  # type: ignore [index]
         return self._rdm1
 
     @property
     def rdm2(self) -> np.ndarray:
-        r"""Calculate two-electron reduced density matrix.
-
-        The trace condition is enforced:
-
-        .. math::
-            \sum_{ij}\Gamma^{[2]}_{iijj} = N_e(N_e-1)
+        """Calculate two-electron reduced density matrix in the active space.
 
         Returns:
             Two-electron reduced density matrix.
@@ -406,11 +399,11 @@ class WaveFunctionSACircuit:
                 dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         if p == q:
                             s_lim = r + 1
                         elif p == r:
@@ -420,7 +413,7 @@ class WaveFunctionSACircuit:
                         else:
                             s_lim = p + 1
                         for s in range(self.num_inactive_orbs, s_lim):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             pdm2_op = (Epq(p, q) * Epq(r, s)).get_folded_operator(
                                 self.num_inactive_orbs, self.num_active_orbs, self.num_virtual_orbs
                             )
@@ -431,11 +424,11 @@ class WaveFunctionSACircuit:
                                 )
                             val = val / self.num_states
                             if q == r:
-                                val -= self.rdm1[p_idx, s_idx]
-                            self._rdm2[p_idx, q_idx, r_idx, s_idx] = val  # type: ignore [index]
-                            self._rdm2[r_idx, s_idx, p_idx, q_idx] = val  # type: ignore [index]
-                            self._rdm2[q_idx, p_idx, s_idx, r_idx] = val  # type: ignore [index]
-                            self._rdm2[s_idx, r_idx, q_idx, p_idx] = val  # type: ignore [index]
+                                val -= self.rdm1[p_, s_]
+                            self._rdm2[p_, q_, r_, s_] = val  # type: ignore
+                            self._rdm2[r_, s_, p_, q_] = val  # type: ignore
+                            self._rdm2[q_, p_, s_, r_] = val  # type: ignore
+                            self._rdm2[s_, r_, q_, p_] = val  # type: ignore
         return self._rdm2
 
     def check_orthonormality(self, overlap_integral: np.ndarray) -> None:
@@ -548,7 +541,7 @@ class WaveFunctionSACircuit:
                 tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
             )
         else:
-            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} expected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
@@ -882,8 +875,8 @@ class WaveFunctionSACircuit:
 
         Args:
             parameters: Ansatz and orbital rotation parameters.
-            theta_optimization: If used in theta optimization.
-            kappa_optimization: If used in kappa optimization.
+            theta_optimization: Doing theta optimization.
+            kappa_optimization: Doing kappa optimization.
 
         Returns:
             State-averaged electronic gradient.

--- a/slowquant/qiskit_interface/sa_circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_circuit_wavefunction.py
@@ -193,10 +193,10 @@ class WaveFunctionSACircuit:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=int)
-        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=int)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
+        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
+        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=np.int64)
+        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=np.int64)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
         self.num_states = len(states[0])
         self.states = states
         # Setup Qiskit stuff

--- a/slowquant/qiskit_interface/sa_circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_circuit_wavefunction.py
@@ -1,5 +1,4 @@
 import time
-from collections.abc import Sequence
 from functools import partial
 
 import numpy as np
@@ -30,17 +29,18 @@ from slowquant.unitary_coupled_cluster.optimizers import Optimizers
 class WaveFunctionSACircuit:
     def __init__(
         self,
-        cas: Sequence[int],
+        active_space: tuple[int, int] | tuple[tuple[int, int], int],
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         states: tuple[list[list[float]], list[list[str]]],
         quantum_interface: QuantumInterface,
-        include_active_kappa: bool = False,
+        include_active_kappa: bool = True,
+        resolve_unpaired_idx: str = "both",
     ) -> None:
         """Initialize circuit based state-averaged UPS wave function.
 
         Args:
-            cas: CAS(num_active_elec, num_active_orbs),
+            active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
                  orbitals are counted in spatial basis.
             mo_coeffs: Initial orbital coefficients.
             integral_generator: Integral generator object.
@@ -50,159 +50,165 @@ class WaveFunctionSACircuit:
                     Ordering: left-to-right, alpha-beta alternating.
             quantum_interface: QuantumInterface.
             include_active_kappa: Include active-active orbital rotations.
+            resolve_unpaired_idx: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                  'both', include spatial index in both occ and unocc idx list.
+                                  'occ', include spatial index only in occ idx list.
+                                  'unocc', include spatial index only in unocc idx list.
         """
-        if len(cas) != 2:
-            raise ValueError(f"cas must have two elements, got {len(cas)} elements.")
         if isinstance(quantum_interface.ansatz, QuantumCircuit):
             print("WARNING: A QI with a custom Ansatz was passed. VQE will only work with COBYLA optimizer.")
-        if cas[0] % 2 == 1:
-            raise ValueError(
-                f"Wave function only implemented for an even number of active electrons. Got; {cas[0]}"
-            )
+        if len(active_space) != 2:
+            raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
+        if isinstance(active_space[0], int):
+            if active_space[0] % 2 == 0:
+                cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
+            else:
+                # Odd number of electrons mean one electron must be unpaired.
+                cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
+        else:
+            cas = ((active_space[0][0], active_space[0][1]), active_space[1])
+        # Init stuff
         self.int_gen = IntegralManager(integral_generator)
-        self._c_mo = mo_coeffs
-        self.inactive_spin_idx = []
-        self.virtual_spin_idx = []
-        self.active_spin_idx = []
-        self.active_occ_spin_idx = []
-        self.active_unocc_spin_idx = []
-        self.active_spin_idx_shifted = []
-        self.active_occ_spin_idx_shifted = []
-        self.active_unocc_spin_idx_shifted = []
-        self.active_idx_shifted = []
-        self.active_occ_idx_shifted = []
-        self.active_unocc_idx_shifted = []
-        self.num_elec = self.int_gen.num_elec
-        self.num_spin_orbs = 2 * len(self.int_gen.kinetic_energy)
-        self.num_orbs = len(self.int_gen.kinetic_energy)
-        self.num_active_elec = cas[0]
-        if self.num_active_elec % 2 != 0:
-            raise ValueError("Number of active electrons has to be even")
-        self.num_active_elec_alpha = self.num_active_elec // 2
-        self.num_active_elec_beta = self.num_active_elec // 2
-        self.num_active_spin_orbs = 0
-        self.num_inactive_spin_orbs = 0
-        self.num_virtual_spin_orbs = 0
+        if np.sum(cas[0]) > self.int_gen.num_elec:
+            raise ValueError("More active electrons than total number electrons.")
+        if (np.sum(cas[0]) % 2 == 0 and self.int_gen.num_elec % 2 == 1) or (
+            np.sum(cas[0]) % 2 == 1 and self.int_gen.num_elec % 2 == 0
+        ):
+            raise ValueError("Specified CAS gives odd number of electrons in inactive space.")
+        self.num_inactive_spin_orbs = self.int_gen.num_elec - int(np.sum(cas[0]))
+        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
+        self.num_active_orbs = cas[1]
+        self.num_active_spin_orbs = 2 * self.num_active_orbs
+        self.num_active_orbs = self.num_active_spin_orbs // 2
+        self.num_virtual_orbs = (
+            len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
+        )
+        if self.num_virtual_orbs < 0:
+            raise ValueError(
+                "Number of inactive + number of active orbitals is larger than total number of orbitals."
+            )
+        self.num_virtual_spin_orbs = 2 * self.num_virtual_orbs
+        self.num_orbs = self.num_inactive_orbs + self.num_active_orbs + self.num_virtual_orbs
+        self.num_spin_orbs = 2 * self.num_orbs
+        self.num_active_elec_alpha = cas[0][0]
+        self.num_active_elec_beta = cas[0][1]
+        self.num_active_elec = self.num_active_elec_alpha + self.num_active_elec_beta
         self._rdm1 = None
         self._rdm2 = None
         self._h_mo = None
         self._g_mo = None
         self._sa_energy: float | None = None
         self._state_energies = None
-        self.num_energy_evals = 0  # number of energy measurements on quanutm
-        active_space = []
-        orbital_counter = 0
-        num_elec = self.int_gen.num_elec
-        for i in range(num_elec - cas[0], num_elec):
-            active_space.append(i)
-            orbital_counter += 1
-        for i in range(num_elec, num_elec + 2 * cas[1] - orbital_counter):
-            active_space.append(i)
-        for i in range(num_elec):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_occ_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
+        self.num_energy_evals = 0
+        self._c_mo = mo_coeffs
+        # Construct spin orbital idx
+        self.inactive_spin_idx = [x for x in range(self.num_inactive_spin_orbs)]
+        self.active_spin_idx = [x + self.num_inactive_spin_orbs for x in range(self.num_active_spin_orbs)]
+        self.virtual_spin_idx = [
+            x + self.num_inactive_spin_orbs + self.num_active_spin_orbs
+            for x in range(self.num_virtual_spin_orbs)
+        ]
+        self.active_occ_spin_idx = []
+        self.active_unocc_spin_idx = []
+        for i, orb_idx in enumerate(self.active_spin_idx):
+            n_ones = 0
+            n_zeros = 0
+            for state in states[1]:
+                for det in state:
+                    if det[i] == "1":
+                        n_ones += 1
+                    else:
+                        n_zeros += 1
+            if n_zeros == 0:
+                # Always occupied in reference
+                self.active_occ_spin_idx.append(orb_idx)
+            elif n_ones == 0:
+                # Always unoccupied in refence
+                self.active_unocc_spin_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "both":
+                self.active_occ_spin_idx.append(orb_idx)
+                self.active_unocc_spin_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "occ":
+                self.active_occ_spin_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "unocc":
+                self.active_unocc_spin_idx.append(orb_idx)
             else:
-                self.inactive_spin_idx.append(i)
-                self.num_inactive_spin_orbs += 1
-        for i in range(num_elec, self.num_spin_orbs):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_unocc_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-            else:
-                self.virtual_spin_idx.append(i)
-                self.num_virtual_spin_orbs += 1
-        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
-        self.num_active_orbs = self.num_active_spin_orbs // 2
-        self.num_virtual_orbs = self.num_virtual_spin_orbs // 2
+                raise ValueError(
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                )
+        self.active_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_spin_idx]
+        self.active_occ_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_occ_spin_idx]
+        self.active_unocc_spin_idx_shifted = [
+            x - self.num_inactive_spin_orbs for x in self.active_unocc_spin_idx
+        ]
         # Construct spatial idx
-        self.inactive_idx: list[int] = []
-        self.virtual_idx: list[int] = []
-        self.active_idx: list[int] = []
-        self.active_occ_idx: list[int] = []
-        self.active_unocc_idx: list[int] = []
-        for idx in self.inactive_spin_idx:
-            if idx // 2 not in self.inactive_idx:
-                self.inactive_idx.append(idx // 2)
-        for idx in self.active_spin_idx:
-            if idx // 2 not in self.active_idx:
-                self.active_idx.append(idx // 2)
-        for idx in self.virtual_spin_idx:
-            if idx // 2 not in self.virtual_idx:
-                self.virtual_idx.append(idx // 2)
-        for idx in self.active_occ_spin_idx:
-            if idx // 2 not in self.active_occ_idx:
-                self.active_occ_idx.append(idx // 2)
-        for idx in self.active_unocc_spin_idx:
-            if idx // 2 not in self.active_unocc_idx:
-                self.active_unocc_idx.append(idx // 2)
-        # Make shifted indices
-        if len(self.active_spin_idx) != 0:
-            active_shift = np.min(self.active_spin_idx)
-            for active_idx in self.active_spin_idx:
-                self.active_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_spin_idx:
-                self.active_occ_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_spin_idx:
-                self.active_unocc_spin_idx_shifted.append(active_idx - active_shift)
-        if len(self.active_idx) != 0:
-            active_shift = np.min(self.active_idx)
-            for active_idx in self.active_idx:
-                self.active_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_idx:
-                self.active_occ_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_idx:
-                self.active_unocc_idx_shifted.append(active_idx - active_shift)
+        self.inactive_idx = [x for x in range(self.num_inactive_orbs)]
+        self.active_idx = [x + self.num_inactive_orbs for x in range(self.num_active_orbs)]
+        self.virtual_idx = [
+            x + self.num_inactive_orbs + self.num_active_orbs for x in range(self.num_virtual_orbs)
+        ]
+        self.active_occ_idx = []
+        self.active_unocc_idx = []
+        for i, orb_idx in enumerate(self.active_idx):
+            n_ones = 0
+            n_zeros = 0
+            for state in states[1]:
+                for det in state:
+                    if det[2 * i] == "1" and det[2 * i + 1] == "1":
+                        n_ones += 1
+                    elif det[2 * i] == "0" and det[2 * i + 1] == "0":
+                        n_zeros += 1
+                    else:
+                        n_zeros += 1
+                        n_ones += 1
+            if n_zeros == 0:
+                # Always occupied in reference
+                self.active_occ_idx.append(orb_idx)
+            elif n_ones == 0:
+                # Always unoccupied in refence
+                self.active_unocc_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "both":
+                self.active_occ_idx.append(orb_idx)
+                self.active_unocc_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "occ":
+                self.active_occ_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "unocc":
+                self.active_unocc_idx.append(orb_idx)
+            else:
+                raise ValueError(
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                )
+        self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
+        self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
+        self.active_unocc_idx_shifted = [x - self.num_inactive_orbs for x in self.active_unocc_idx]
         # Find non-redundant kappas
         self._kappa = []
         kappa_idx = []
         kappa_idx_dagger = []
-        kappa_no_activeactive_idx = []
-        kappa_no_activeactive_idx_dagger = []
-        kappa_redundant_idx = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
+        # Loop over all q>p orb combinations.
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
+                # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
                 if not include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
-                        kappa_redundant_idx.append((p, q))
                         continue
-                if not (p in self.active_idx and q in self.active_idx):
-                    kappa_no_activeactive_idx.append((p, q))
-                    kappa_no_activeactive_idx_dagger.append((q, p))
+                # the rest is non-redundant
                 self._kappa.append(0.0)
                 self._kappa_old.append(0.0)
                 kappa_idx.append((p, q))
                 kappa_idx_dagger.append((q, p))
-        # HF like orbital rotation indices
-        kappa_hf_like_idx = []
-        for p in range(0, self.num_orbs):
-            for q in range(p + 1, self.num_orbs):
-                if p in self.inactive_idx and q in self.virtual_idx:
-                    kappa_hf_like_idx.append((p, q))
-                elif p in self.inactive_idx and q in self.active_unocc_idx:
-                    kappa_hf_like_idx.append((p, q))
-                elif p in self.active_occ_idx and q in self.virtual_idx:
-                    kappa_hf_like_idx.append((p, q))
         self.kappa_idx = np.array(kappa_idx, dtype=int)
-        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=int)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
+        # States
         self.num_states = len(states[0])
         self.states = states
         # Setup Qiskit stuff
         self.QI = quantum_interface
-        if self.QI.ansatz_options.get("do_pp"):
-            raise ValueError("perfect pairing is not supported for Ansatz in SA UPS wave functions.")
         self.QI.construct_circuit(
             self.active_occ_idx_shifted,
             self.active_unocc_idx_shifted,
@@ -362,7 +368,7 @@ class WaveFunctionSACircuit:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs))
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_idx = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -397,7 +403,8 @@ class WaveFunctionSACircuit:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_idx = p - self.num_inactive_orbs
@@ -485,42 +492,90 @@ class WaveFunctionSACircuit:
             sa_energy += self.QI.quantum_expectation_value_csfs((coeffs, csf), H, (coeffs, csf))
         return sa_energy / self.num_states
 
-    def run_wf_optimization_2step(
+    def run_wf_optimization(
         self,
-        optimizer_name: str,
-        orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
+        orbital_optimization: bool = False,
+        theta_optimization: bool = True,
+        one_step_optimizer: str = "BFGS",
+        theta_optimizer: str = "BFGS",
+        orbital_optimizer: str = "BFGS",
+        opt_type: str = "1step",
         is_silent_subiterations: bool = False,
     ) -> None:
-        """Run two step optimization of wave function.
+        """Run variational optimization of wavefunction.
 
         Args:
-            optimizer_name: Name of optimizer.
-            orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
+            tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            is_silent_subiterations: Silence subiterations.
+            orbital_optimization: Perform orbital optimization.
+            theta_optimization: Perform theta optimization.
+            one_step_optimizer: Optimizer used for 1step optimizer.
+            theta_optimizer: Optimizer used for theta optimization in 2step optimizer.
+            orbital_optimizer: Optimizer used for orbital optimization in 2step optimizer.
+            opt_type: Optimization type, can be '1step' or '2step'.
+            is_silent_subiterations: Silence sub iterations in 2step.
         """
-        if isinstance(self.QI.ansatz, QuantumCircuit) and optimizer_name.lower() not in ("cobyla", "cobyqa"):
-            raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
+        if len(self.kappa) == 0 and orbital_optimization:
+            print("No kappa parameters turning off orbital optimization.")
+            orbital_optimization = False
+        if len(self.thetas) == 0 and theta_optimization:
+            print("No thetas parameters turning off theta optimization.")
+            theta_optimization = False
+        if opt_type.lower() == "2step" and (not orbital_optimization or not theta_optimization):
+            if not orbital_optimization:
+                print("Orbital optimization not requested changing optimizer type to 1step.")
+                opt_type = "1step"
+            elif not theta_optimization:
+                print("theta optimization not requested changing optimizer type to 1step.")
+                opt_type = "1step"
+        if theta_optimization and isinstance(self.QI.ansatz, QuantumCircuit):
+            if opt_type.lower() == "1step" and one_step_optimizer.lower() not in ("cobyla", "cobyqa"):
+                raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
+            elif opt_type.lower() == "2step" and theta_optimizer.lower() not in ("cobyla", "cobyqa"):
+                raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
         print("### Parameters information:")
         if orbital_optimization:
             print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {len(self.thetas)}")
+        if theta_optimization:
+            print("### Number theta: {len(self.thetas)}")
+        if opt_type.lower() == "1step":
+            self._run_wf_optimization_1step(
+                tol, maxiter, orbital_optimization, theta_optimization, one_step_optimizer
+            )
+        elif opt_type.lower() == "2step":
+            self._run_wf_optimization_2step(
+                tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
+            )
+        else:
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
+
+    def _run_wf_optimization_2step(
+        self,
+        tol: float,
+        maxiter: int,
+        theta_optimizer: str,
+        orbital_optimizer: str,
+        is_silent_subiterations: bool,
+    ) -> None:
+        """Run two step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        for full_iter in range(0, int(maxiter)):
+        for full_iter in range(0, maxiter):
             full_start = time.time()
-
             # Do ansatz optimization
             if not is_silent_subiterations:
                 print("--------Ansatz optimization")
                 print(
                     "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
                 )
-            if optimizer_name.lower() in ("rotosolve",):
+            if theta_optimizer.lower() == "rotosolve":
                 # For RotoSolve type solvers the energy per state is needed in the optimization,
                 # instead of only the state-averaged energy.
                 energy_theta = partial(
@@ -542,7 +597,7 @@ class WaveFunctionSACircuit:
             )
             optimizer = Optimizers(
                 energy_theta,
-                optimizer_name,
+                theta_optimizer,
                 grad=gradient_theta,
                 maxiter=maxiter,
                 tol=tol,
@@ -557,47 +612,37 @@ class WaveFunctionSACircuit:
             )
             self.thetas = res.x.tolist()
 
-            if orbital_optimization and len(self.kappa) != 0:
-                if not is_silent_subiterations:
-                    print("--------Orbital optimization")
-                    print(
-                        "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
-                    )
-                energy_oo = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
+            if not is_silent_subiterations:
+                print("--------Orbital optimization")
+                print(
+                    "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
                 )
-                gradient_oo = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
+            energy_oo = partial(
+                self._calc_energy_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
+            gradient_oo = partial(
+                self._calc_gradient_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
 
-                optimizer = Optimizers(
-                    energy_oo,
-                    "l-bfgs-b",
-                    grad=gradient_oo,
-                    maxiter=maxiter,
-                    tol=tol,
-                    is_silent=is_silent_subiterations,
-                    energy_eval_callback=lambda: self.num_energy_evals,
-                )
-                self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
-                self._E_opt_old = 0.0
-                res = optimizer.minimize([0.0] * len(self.kappa_idx))
-                for i in range(len(self.kappa)):
-                    self._kappa[i] = 0.0
-                    self._kappa_old[i] = 0.0
-            else:
-                # If there is no orbital optimization, then the algorithm is already converged.
-                e_new = res.fun
-                if orbital_optimization and len(self.kappa) == 0:
-                    print(
-                        "WARNING: No orbital optimization performed, because there is no non-redundant orbital parameters"
-                    )
-                break
-
+            optimizer = Optimizers(
+                energy_oo,
+                orbital_optimizer,
+                grad=gradient_oo,
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
+                energy_eval_callback=lambda: self.num_energy_evals,
+            )
+            self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
+            self._E_opt_old = 0.0
+            res = optimizer.minimize([0.0] * len(self.kappa_idx))
+            for i in range(len(self.kappa)):
+                self._kappa[i] = 0.0
+                self._kappa_old[i] = 0.0
             e_new = res.fun
             time_str = f"{time.time() - full_start:7.2f}"
             e_str = f"{e_new:3.12f}"
@@ -611,76 +656,42 @@ class WaveFunctionSACircuit:
         self._do_state_ci()
         self._sa_energy = res.fun
 
-    def run_wf_optimization_1step(
+    def _run_wf_optimization_1step(
         self,
-        optimizer_name: str,
-        orbital_optimization: bool = False,
-        tol: float = 1e-10,
-        maxiter: int = 1000,
+        tol: float,
+        maxiter: int,
+        orbital_optimization: bool,
+        theta_optimization: bool,
+        one_step_optimizer: str,
     ) -> None:
         """Run one step optimization of wave function.
 
-        Args:
-            optimizer_name: Name of optimizer.
-            orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
-            maxiter: Maximum number of iterations.
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
         """
-        if isinstance(self.QI.ansatz, QuantumCircuit) and optimizer_name.lower() not in ("cobyla", "cobyqa"):
-            raise ValueError("Custom Ansatz in QI only works with COBYLA and COBYQA as optimizer.")
-        print("### Parameters information:")
-        if orbital_optimization:
-            print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {len(self.thetas)}")
-        if optimizer_name.lower() == "rotosolve":
-            if orbital_optimization and len(self.kappa) != 0:
-                raise ValueError(
-                    "Cannot use RotoSolve together with orbital optimization in the one-step solver."
-                )
-
+        if one_step_optimizer.lower() == "rotosolve" and orbital_optimization:
+            raise ValueError(
+                "Cannot use RotoSolve together with orbital optimization in the one-step solver."
+            )
         print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
+        energy = partial(
+            self._calc_energy_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        gradient = partial(
+            self._calc_gradient_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
         if orbital_optimization:
-            if len(self.thetas) > 0:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-            else:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-        else:
-            energy = partial(
-                self._calc_energy_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-            gradient = partial(
-                self._calc_gradient_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+            if theta_optimization:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
         else:
             parameters = self.thetas
-        if optimizer_name.lower() in ("rotosolve",):
+        if one_step_optimizer.lower() == "rotosolve":
             # For RotoSolve type solvers the energy per state is needed in the optimization,
             # instead of only the state-averaged energy.
             energy = partial(
@@ -691,7 +702,7 @@ class WaveFunctionSACircuit:
             )
         optimizer = Optimizers(
             energy,
-            optimizer_name,
+            one_step_optimizer,
             grad=gradient,
             maxiter=maxiter,
             tol=tol,
@@ -704,7 +715,8 @@ class WaveFunctionSACircuit:
             extra_options={"R": self.QI.grad_param_R, "param_names": self.QI.param_names},
         )
         if orbital_optimization:
-            self.thetas = res.x[len(self.kappa) :].tolist()
+            if theta_optimization:
+                self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0
                 self._kappa_old[i] = 0.0

--- a/slowquant/qiskit_interface/sa_circuit_wavefunction.py
+++ b/slowquant/qiskit_interface/sa_circuit_wavefunction.py
@@ -193,10 +193,10 @@ class WaveFunctionSACircuit:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
-        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=np.int64)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=np.int64)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
+        self.kappa_idx = np.array(kappa_idx, dtype=int)
+        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=int)
+        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         self.num_states = len(states[0])
         self.states = states
         # Setup Qiskit stuff

--- a/slowquant/unitary_coupled_cluster/ci_spaces.py
+++ b/slowquant/unitary_coupled_cluster/ci_spaces.py
@@ -95,7 +95,7 @@ def get_indexing(
         num_virtual_orbs,
         num_active_elec_alpha,
         num_active_elec_beta,
-        np.array(idx2det, dtype=int),
+        np.array(idx2det, dtype=np.int64),
         det2idx,
     )
 
@@ -252,7 +252,7 @@ def get_indexing_extended(
         0,
         num_active_elec_alpha + num_inactive_orbs,
         num_active_elec_beta + num_inactive_orbs,
-        np.array(idx2det, dtype=int),
+        np.array(idx2det, dtype=np.int64),
         det2idx,
     )
     ci_info.space_extension_offset = num_inactive_orbs

--- a/slowquant/unitary_coupled_cluster/ci_spaces.py
+++ b/slowquant/unitary_coupled_cluster/ci_spaces.py
@@ -95,7 +95,7 @@ def get_indexing(
         num_virtual_orbs,
         num_active_elec_alpha,
         num_active_elec_beta,
-        np.array(idx2det, dtype=np.int64),
+        np.array(idx2det, dtype=int),
         det2idx,
     )
 
@@ -252,7 +252,7 @@ def get_indexing_extended(
         0,
         num_active_elec_alpha + num_inactive_orbs,
         num_active_elec_beta + num_inactive_orbs,
-        np.array(idx2det, dtype=np.int64),
+        np.array(idx2det, dtype=int),
         det2idx,
     )
     ci_info.space_extension_offset = num_inactive_orbs

--- a/slowquant/unitary_coupled_cluster/integral_manager.py
+++ b/slowquant/unitary_coupled_cluster/integral_manager.py
@@ -13,6 +13,7 @@ class IntegralManager:
         "_h_ao",
         "_kinetic_energy",
         "_nuclear_electron_attraction",
+        "_overlap",
         "int_obj",
     )
 
@@ -28,6 +29,7 @@ class IntegralManager:
         self._electron_electron_repulsion: np.ndarray | None = None
         self._electric_dipole: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
         self._h_ao: np.ndarray | None = None
+        self._overlap: np.ndarray | None = None
 
     @property
     def num_elec(self) -> int:
@@ -123,3 +125,17 @@ class IntegralManager:
             raise ValueError("Got unknown integral object, {type(self.int_obj)}")
         self._h_ao = h_core
         return h_core
+
+    @property
+    def overlap(self) -> np.ndarray:
+        """Electron overlap integrals."""
+        if isinstance(self._overlap, np.ndarray):
+            return self._overlap
+        if isinstance(self.int_obj, SlowQuant):
+            overlap_int = self.int_obj.integral.overlap_matrix
+        elif isinstance(self.int_obj, pyscf.gto.mole.Mole):
+            overlap_int = self.int_obj.intor("int1e_ovlp")
+        else:
+            raise ValueError("Got unknown integral object, {type(self.int_obj)}")
+        self._overlap = overlap_int
+        return overlap_int

--- a/slowquant/unitary_coupled_cluster/linear_response/allselfconsistent.py
+++ b/slowquant/unitary_coupled_cluster/linear_response/allselfconsistent.py
@@ -65,12 +65,12 @@ class LinearResponse(LinearResponseBaseClass):
         else:
             raise ValueError(f"Got incompatible wave function type, {type(self.wf)}")
         num_det = len(ci_info.idx2det)
-        self.csf_coeffs = np.zeros(num_det)
-        hf_det = int(
-            "1" * self.wf.int_gen.num_elec + "0" * (self.wf.num_spin_orbs - self.wf.int_gen.num_elec), 2
+        self.ref_coeffs = np.zeros(num_det)
+        ref_det = (
+            "1" * self.wf.num_inactive_spin_orbs + self.wf._ref_det + "0" * self.wf.num_virtual_spin_orbs
         )
-        self.csf_coeffs[ci_info.det2idx[hf_det]] = 1
-        self.ci_coeffs = propagate_state(["U"], self.csf_coeffs, *self.index_info_extended)
+        self.ref_coeffs[ci_info.det2idx[int(ref_det, 2)]] = 1
+        self.ci_coeffs = propagate_state(["U"], self.ref_coeffs, *self.index_info_extended)
         self.q_ops: list[FermionicOperator] = []
         for i, a in self.wf.kappa_hf_like_idx:
             op = 2 ** (-1 / 2) * Epq(a, i)
@@ -103,7 +103,7 @@ class LinearResponse(LinearResponseBaseClass):
         grad = np.zeros(2 * len(self.G_ops))
         UdH00_ket = propagate_state(["Ud", self.H_0i_0a], self.ci_coeffs, *self.index_info_extended)
         for i, op in enumerate(self.G_ops):
-            G_ket = propagate_state([op], self.csf_coeffs, *self.index_info_extended)
+            G_ket = propagate_state([op], self.ref_coeffs, *self.index_info_extended)
             # - <0| H U G |CSF>
             grad[i] = -expectation_value(
                 UdH00_ket,
@@ -127,14 +127,14 @@ class LinearResponse(LinearResponseBaseClass):
         for j, qJ in enumerate(self.q_ops):
             UdHUqJ_ket = propagate_state(
                 ["Ud", H_2i_2a, "U", qJ],
-                self.csf_coeffs,
+                self.ref_coeffs,
                 *self.index_info_extended,
                 do_unsafe=True,  # type: ignore
             )
             qJUdH_ket = propagate_state([qJ], UdH_ket, *self.index_info_extended, do_unsafe=True)  # type: ignore
             qJdUdH_ket = propagate_state([qJ.dagger], UdH_ket, *self.index_info_extended, do_unsafe=True)  # type: ignore
             for i, qI in enumerate(self.q_ops[j:], j):
-                qI_ket = propagate_state([qI], self.csf_coeffs, *self.index_info_extended, do_unsafe=True)  # type: ignore
+                qI_ket = propagate_state([qI], self.ref_coeffs, *self.index_info_extended, do_unsafe=True)  # type: ignore
                 # Make A
                 # <CSF| qId Ud H U qJ |CSF>
                 val = expectation_value(
@@ -161,7 +161,7 @@ class LinearResponse(LinearResponseBaseClass):
                     * expectation_value(
                         UdH_ket,
                         [qI.dagger, qJ],
-                        self.csf_coeffs,
+                        self.ref_coeffs,
                         *self.index_info_extended,
                     )
                 )
@@ -181,7 +181,7 @@ class LinearResponse(LinearResponseBaseClass):
         for j, qJ in enumerate(self.q_ops):
             UdHUq_ket = propagate_state(
                 ["Ud", self.H_1i_1a, "U", qJ],
-                self.csf_coeffs,
+                self.ref_coeffs,
                 *self.index_info_extended,
                 do_unsafe=True,  # type: ignore
             )
@@ -192,7 +192,7 @@ class LinearResponse(LinearResponseBaseClass):
                 do_unsafe=True,  # type: ignore
             )
             for i, GI in enumerate(self.G_ops):
-                G_ket = propagate_state([GI], self.csf_coeffs, *self.index_info_extended)
+                G_ket = propagate_state([GI], self.ref_coeffs, *self.index_info_extended)
                 # Make A
                 # <CSF| Gd Ud H U q |CSF>
                 val = expectation_value(
@@ -219,7 +219,7 @@ class LinearResponse(LinearResponseBaseClass):
                     1
                     / 2
                     * expectation_value(
-                        self.csf_coeffs,
+                        self.ref_coeffs,
                         [qJ.dagger, GI.dagger],
                         UdH_ket,
                         *self.index_info_extended,
@@ -228,12 +228,12 @@ class LinearResponse(LinearResponseBaseClass):
                 self.B[i + idx_shift, j] = self.B[j, i + idx_shift] = val
         for j, GJ in enumerate(self.G_ops):
             UdHUGJ_ket = propagate_state(
-                ["Ud", self.H_0i_0a, "U", GJ], self.csf_coeffs, *self.index_info_extended
+                ["Ud", self.H_0i_0a, "U", GJ], self.ref_coeffs, *self.index_info_extended
             )
             GJUdH_ket = propagate_state([GJ], UdH00_ket, *self.index_info_extended)
             GJdUdH_ket = propagate_state([GJ.dagger], UdH00_ket, *self.index_info_extended)
             for i, GI in enumerate(self.G_ops[j:], j):
-                GI_ket = propagate_state([GI], self.csf_coeffs, *self.index_info_extended)
+                GI_ket = propagate_state([GI], self.ref_coeffs, *self.index_info_extended)
                 # Make A
                 # <CSF| GId Ud H U GJ |CSF>
                 val = expectation_value(
@@ -260,7 +260,7 @@ class LinearResponse(LinearResponseBaseClass):
                     * expectation_value(
                         UdH00_ket,
                         [GI.dagger, GJ],
-                        self.csf_coeffs,
+                        self.ref_coeffs,
                         *self.index_info_extended,
                     )
                 )
@@ -321,12 +321,12 @@ class LinearResponse(LinearResponseBaseClass):
                 q_part_x -= self.Z_q_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [mux_op_q, "U", q],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                     do_unsafe=True,  # type: ignore
                 )
                 q_part_x += self.Y_q_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [q.dagger, "Ud", mux_op_q],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -335,12 +335,12 @@ class LinearResponse(LinearResponseBaseClass):
                 q_part_y -= self.Z_q_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muy_op_q, "U", q],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                     do_unsafe=True,  # type: ignore
                 )
                 q_part_y += self.Y_q_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [q.dagger, "Ud", muy_op_q],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -349,12 +349,12 @@ class LinearResponse(LinearResponseBaseClass):
                 q_part_z -= self.Z_q_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muz_op_q, "U", q],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                     do_unsafe=True,  # type: ignore
                 )
                 q_part_z += self.Y_q_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [q.dagger, "Ud", muz_op_q],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -367,11 +367,11 @@ class LinearResponse(LinearResponseBaseClass):
                 g_part_x -= self.Z_G_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [mux_op_G, "U", G],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 g_part_x += self.Y_G_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [G.dagger, "Ud", mux_op_G],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -379,11 +379,11 @@ class LinearResponse(LinearResponseBaseClass):
                 g_part_y -= self.Z_G_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muy_op_G, "U", G],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 g_part_y += self.Y_G_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [G.dagger, "Ud", muy_op_G],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -391,11 +391,11 @@ class LinearResponse(LinearResponseBaseClass):
                 g_part_z -= self.Z_G_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muz_op_G, "U", G],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 g_part_z += self.Y_G_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [G.dagger, "Ud", muz_op_G],
                     self.ci_coeffs,
                     *self.index_info_extended,

--- a/slowquant/unitary_coupled_cluster/linear_response/allstatetransfer.py
+++ b/slowquant/unitary_coupled_cluster/linear_response/allstatetransfer.py
@@ -65,12 +65,12 @@ class LinearResponse(LinearResponseBaseClass):
         else:
             raise ValueError(f"Got incompatible wave function type, {type(self.wf)}")
         num_det = len(ci_info.idx2det)
-        self.csf_coeffs = np.zeros(num_det)
-        hf_det = int(
-            "1" * self.wf.int_gen.num_elec + "0" * (self.wf.num_spin_orbs - self.wf.int_gen.num_elec), 2
+        self.ref_coeffs = np.zeros(num_det)
+        ref_det = (
+            "1" * self.wf.num_inactive_spin_orbs + self.wf._ref_det + "0" * self.wf.num_virtual_spin_orbs
         )
-        self.csf_coeffs[ci_info.det2idx[hf_det]] = 1
-        self.ci_coeffs = propagate_state(["U"], self.csf_coeffs, *self.index_info_extended)
+        self.ref_coeffs[ci_info.det2idx[int(ref_det, 2)]] = 1
+        self.ci_coeffs = propagate_state(["U"], self.ref_coeffs, *self.index_info_extended)
         self.q_ops: list[FermionicOperator] = []
         for i, a in self.wf.kappa_hf_like_idx:
             op = 2 ** (-1 / 2) * Epq(a, i)
@@ -107,7 +107,7 @@ class LinearResponse(LinearResponseBaseClass):
             *self.index_info_extended,
         )
         for i, op in enumerate(self.G_ops):
-            G_ket = propagate_state([op], self.csf_coeffs, *self.index_info_extended)
+            G_ket = propagate_state([op], self.ref_coeffs, *self.index_info_extended)
             # - <0| H U G |CSF>
             grad[i] = -expectation_value(
                 UdH_ket,
@@ -129,7 +129,7 @@ class LinearResponse(LinearResponseBaseClass):
         for j, qJ in enumerate(self.q_ops):
             UdHUqJ = propagate_state(
                 ["Ud", H_2i_2a, "U", qJ],
-                self.csf_coeffs,
+                self.ref_coeffs,
                 *self.index_info_extended,
                 do_unsafe=True,  # type: ignore
             )
@@ -137,7 +137,7 @@ class LinearResponse(LinearResponseBaseClass):
                 # Make A
                 # <CSF| qId Ud H U qJ |CSF>
                 val = expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [qI.dagger],
                     UdHUqJ,
                     *self.index_info_extended,
@@ -152,7 +152,7 @@ class LinearResponse(LinearResponseBaseClass):
                 # Make A
                 # <CSF| Gd Ud H U q |CSF>
                 val = expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [GI.dagger],
                     UdHUqJ,
                     *self.index_info_extended,
@@ -161,14 +161,14 @@ class LinearResponse(LinearResponseBaseClass):
         for j, GJ in enumerate(self.G_ops):
             UdHUGJ = propagate_state(
                 ["Ud", self.H_0i_0a, "U", GJ],
-                self.csf_coeffs,
+                self.ref_coeffs,
                 *self.index_info_extended,
             )
             for i, GI in enumerate(self.G_ops[j:], j):
                 # Make A
                 # <CSF| GId Ud H U GJ |CSF>
                 val = expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [GI.dagger],
                     UdHUGJ,
                     *self.index_info_extended,
@@ -223,12 +223,12 @@ class LinearResponse(LinearResponseBaseClass):
                 q_part_x -= self.Z_q_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [mux_op_q, "U", q],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                     do_unsafe=True,  # type: ignore
                 )
                 q_part_x += self.Y_q_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [q.dagger, "Ud", mux_op_q],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -237,12 +237,12 @@ class LinearResponse(LinearResponseBaseClass):
                 q_part_y -= self.Z_q_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muy_op_q, "U", q],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                     do_unsafe=True,  # type: ignore
                 )
                 q_part_y += self.Y_q_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [q.dagger, "Ud", muy_op_q],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -251,12 +251,12 @@ class LinearResponse(LinearResponseBaseClass):
                 q_part_z -= self.Z_q_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muz_op_q, "U", q],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                     do_unsafe=True,  # type: ignore
                 )
                 q_part_z += self.Y_q_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [q.dagger, "Ud", muz_op_q],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -269,11 +269,11 @@ class LinearResponse(LinearResponseBaseClass):
                 g_part_x -= self.Z_G_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [mux_op_G, "U", G],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 g_part_x += self.Y_G_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [G.dagger, "Ud", mux_op_G],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -281,11 +281,11 @@ class LinearResponse(LinearResponseBaseClass):
                 g_part_y -= self.Z_G_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muy_op_G, "U", G],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 g_part_y += self.Y_G_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [G.dagger, "Ud", muy_op_G],
                     self.ci_coeffs,
                     *self.index_info_extended,
@@ -293,11 +293,11 @@ class LinearResponse(LinearResponseBaseClass):
                 g_part_z -= self.Z_G_normed[i, state_number] * expectation_value(
                     self.ci_coeffs,
                     [muz_op_G, "U", G],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 g_part_z += self.Y_G_normed[i, state_number] * expectation_value(
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     [G.dagger, "Ud", muz_op_G],
                     self.ci_coeffs,
                     *self.index_info_extended,

--- a/slowquant/unitary_coupled_cluster/linear_response/lr_baseclass.py
+++ b/slowquant/unitary_coupled_cluster/linear_response/lr_baseclass.py
@@ -56,6 +56,10 @@ class LinearResponseBaseClass:
             )
         else:
             raise ValueError(f"Got incompatible wave function type, {type(self.wf)}")
+        for i in range(self.wf.num_active_orbs):
+            if self.wf._ref_det[2 * i] != self.wf._ref_det[2 * i + 1]:
+                print("WARNING: Linear response is not tested for open-shell reference determinants.")
+                break
 
         self.G_ops: list[FermionicOperator] = []
         self.q_ops: list[FermionicOperator] = []

--- a/slowquant/unitary_coupled_cluster/linear_response/projected_statetransfer.py
+++ b/slowquant/unitary_coupled_cluster/linear_response/projected_statetransfer.py
@@ -65,7 +65,7 @@ class LinearResponse(LinearResponseBaseClass):
         for i, op in enumerate(self.G_ops):
             G_ket = propagate_state(
                 [op],
-                self.wf.csf_coeffs,
+                self.wf.ref_coeffs,
                 *self.index_info,
             )
             # <0| H U G |CSF>
@@ -112,7 +112,7 @@ class LinearResponse(LinearResponseBaseClass):
         for j, qJ in enumerate(self.q_ops):
             UdHq_ket = propagate_state(["Ud", self.H_1i_1a * qJ], self.wf.ci_coeffs, *self.index_info)
             for i, GI in enumerate(self.G_ops):
-                G_ket = propagate_state([GI], self.wf.csf_coeffs, *self.index_info)
+                G_ket = propagate_state([GI], self.wf.ref_coeffs, *self.index_info)
                 # Make A
                 # <CSF| Gd Ud H q |0>
                 val = expectation_value(
@@ -125,14 +125,14 @@ class LinearResponse(LinearResponseBaseClass):
         for j, GJ in enumerate(self.G_ops):
             UdHUGJ_ket = propagate_state(
                 ["Ud", self.H_0i_0a, "U", GJ],
-                self.wf.csf_coeffs,
+                self.wf.ref_coeffs,
                 *self.index_info,
             )
             for i, GI in enumerate(self.G_ops[j:], j):
                 # Make A
                 # <CSF| GId Ud H U GJ |CSF>
                 val = expectation_value(
-                    self.wf.csf_coeffs,
+                    self.wf.ref_coeffs,
                     [GI.dagger],
                     UdHUGJ_ket,
                     *self.index_info,
@@ -218,7 +218,7 @@ class LinearResponse(LinearResponseBaseClass):
             for i, G in enumerate(self.G_ops):
                 G_ket = propagate_state(
                     [G],
-                    self.wf.csf_coeffs,
+                    self.wf.ref_coeffs,
                     *self.index_info,
                 )
                 # -Z * <0| mux U G | CSF>

--- a/slowquant/unitary_coupled_cluster/linear_response/selfconsistent.py
+++ b/slowquant/unitary_coupled_cluster/linear_response/selfconsistent.py
@@ -67,12 +67,12 @@ class LinearResponse(LinearResponseBaseClass):
         else:
             raise ValueError(f"Got incompatible wave function type, {type(self.wf)}")
         num_det = len(ci_info.idx2det)
-        self.csf_coeffs = np.zeros(num_det)
-        hf_det = int(
-            "1" * self.wf.int_gen.num_elec + "0" * (self.wf.num_spin_orbs - self.wf.int_gen.num_elec), 2
+        self.ref_coeffs = np.zeros(num_det)
+        ref_det = (
+            "1" * self.wf.num_inactive_spin_orbs + self.wf._ref_det + "0" * self.wf.num_virtual_spin_orbs
         )
-        self.csf_coeffs[ci_info.det2idx[hf_det]] = 1
-        self.ci_coeffs = propagate_state(["U"], self.csf_coeffs, *self.index_info_extended)
+        self.ref_coeffs[ci_info.det2idx[int(ref_det, 2)]] = 1
+        self.ci_coeffs = propagate_state(["U"], self.ref_coeffs, *self.index_info_extended)
         idx_shift = len(self.q_ops)
         print("Gs", len(self.G_ops))
         print("qs", len(self.q_ops))
@@ -94,7 +94,7 @@ class LinearResponse(LinearResponseBaseClass):
         for i, op in enumerate(self.G_ops):
             G_ket = propagate_state(
                 [op],
-                self.csf_coeffs,
+                self.ref_coeffs,
                 *self.index_info_extended,
             )
             # <0| H U G |CSF>
@@ -159,7 +159,7 @@ class LinearResponse(LinearResponseBaseClass):
             for i, GI in enumerate(self.G_ops):
                 G_ket = propagate_state(
                     [GI],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 # Make A
@@ -211,7 +211,7 @@ class LinearResponse(LinearResponseBaseClass):
         for j, GJ in enumerate(self.G_ops):
             UdHUGJ_ket = propagate_state(
                 ["Ud", self.H_0i_0a, "U", GJ],
-                self.csf_coeffs,
+                self.ref_coeffs,
                 *self.index_info_extended,
             )
             GJUdH_ket = propagate_state(
@@ -227,7 +227,7 @@ class LinearResponse(LinearResponseBaseClass):
             for i, GI in enumerate(self.G_ops[j:], j):
                 GI_ket = propagate_state(
                     [GI],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 # Make A
@@ -256,7 +256,7 @@ class LinearResponse(LinearResponseBaseClass):
                     * expectation_value(
                         UdH00_ket,
                         [GI.dagger, GJ],
-                        self.csf_coeffs,
+                        self.ref_coeffs,
                         *self.index_info_extended,
                     )
                 )
@@ -348,7 +348,7 @@ class LinearResponse(LinearResponseBaseClass):
             for i, G in enumerate(self.G_ops):
                 G_ket = propagate_state(
                     [G],
-                    self.csf_coeffs,
+                    self.ref_coeffs,
                     *self.index_info_extended,
                 )
                 # -Z * <0| mux U G | CSF>

--- a/slowquant/unitary_coupled_cluster/linear_response/statetransfer.py
+++ b/slowquant/unitary_coupled_cluster/linear_response/statetransfer.py
@@ -56,7 +56,7 @@ class LinearResponse(LinearResponseBaseClass):
         for i, op in enumerate(self.G_ops):
             G_ket = propagate_state(
                 [op],
-                self.wf.csf_coeffs,
+                self.wf.ref_coeffs,
                 *self.index_info,
             )
             # - <0| H U G |CSF>
@@ -109,7 +109,7 @@ class LinearResponse(LinearResponseBaseClass):
             UdHq_ket = propagate_state(["Ud", self.H_1i_1a * qJ], self.wf.ci_coeffs, *self.index_info)
             UdqdH_ket = propagate_state(["Ud", qJ.dagger * self.H_1i_1a], self.wf.ci_coeffs, *self.index_info)
             for i, GI in enumerate(self.G_ops):
-                G_ket = propagate_state([GI], self.wf.csf_coeffs, *self.index_info)
+                G_ket = propagate_state([GI], self.wf.ref_coeffs, *self.index_info)
                 # Make A
                 # <CSF| Gd Ud H q |0>
                 val = expectation_value(
@@ -135,14 +135,14 @@ class LinearResponse(LinearResponseBaseClass):
         for j, GJ in enumerate(self.G_ops):
             UdHUGJ = propagate_state(
                 ["Ud", self.H_0i_0a, "U", GJ],
-                self.wf.csf_coeffs,
+                self.wf.ref_coeffs,
                 *self.index_info,
             )
             for i, GI in enumerate(self.G_ops[j:], j):
                 # Make A
                 # <CSF| GId Ud H U GJ | CSF>
                 val = expectation_value(
-                    self.wf.csf_coeffs,
+                    self.wf.ref_coeffs,
                     [GI.dagger],
                     UdHUGJ,
                     *self.index_info,
@@ -228,7 +228,7 @@ class LinearResponse(LinearResponseBaseClass):
             for i, G in enumerate(self.G_ops):
                 G_ket = propagate_state(
                     [G],
-                    self.wf.csf_coeffs,
+                    self.wf.ref_coeffs,
                     *self.index_info,
                 )
                 # -Z * <0| mux U G | CSF>

--- a/slowquant/unitary_coupled_cluster/operator_state_algebra.py
+++ b/slowquant/unitary_coupled_cluster/operator_state_algebra.py
@@ -426,9 +426,9 @@ def build_operator_matrix(op: FermionicOperator, ci_info: CI_Info, do_unsafe: bo
     det2idx = ci_info.det2idx
     num_active_orbs = ci_info.num_active_orbs
     num_dets = len(idx2det)  # number of spin and particle conserving determinants
-    op_mat = np.zeros((num_dets, num_dets), dtype=np.float64)  # basis
+    op_mat = np.zeros((num_dets, num_dets), dtype=float)  # basis
     # Create bitstrings for parity check. Contains occupied determinant up to orbital index.
-    parity_check = np.zeros(2 * num_active_orbs + 1, dtype=np.int64)
+    parity_check = np.zeros(2 * num_active_orbs + 1, dtype=int)
     num = 0
     for i in range(2 * num_active_orbs - 1, -1, -1):
         num += 2**i
@@ -450,10 +450,10 @@ def build_operator_matrix(op: FermionicOperator, ci_info: CI_Info, do_unsafe: bo
         for idx in create_idx:
             if idx not in anni_idx:
                 create_screen.append(idx)
-        a_string = np.array(anni_idx + create_idx, dtype=np.int64)
-        create_screen = np.array(create_screen, dtype=np.int64)
-        create_idx = np.array(create_idx, dtype=np.int64)
-        anni_idx = np.array(anni_idx, dtype=np.int64)
+        a_string = np.array(anni_idx + create_idx, dtype=int)
+        create_screen = np.array(create_screen, dtype=int)
+        create_idx = np.array(create_idx, dtype=int)
+        anni_idx = np.array(anni_idx, dtype=int)
         op_mat = add_operator_matrix(
             op_mat,
             a_string,
@@ -513,9 +513,9 @@ def propagate_state(
     else:
         is_parallel = True
     new_state = np.copy(state)
-    tmp_state = np.zeros_like(state, dtype=np.float64)
+    tmp_state = np.zeros_like(state, dtype=float)
     # Create bitstrings for parity check. Contains occupied determinant up to orbital index.
-    parity_check = np.zeros(2 * num_active_orbs + 1, dtype=np.int64)
+    parity_check = np.zeros(2 * num_active_orbs + 1, dtype=int)
     num = 0
     for i in range(2 * num_active_orbs - 1, -1, -1):
         num += 2**i
@@ -576,9 +576,9 @@ def propagate_state(
                     for idx in anni_idx:
                         if idx not in create_idx:
                             anni_screen.append(idx)
-                    a_string = np.array(create_idx + anni_idx, dtype=np.int64)
-                    anni_screen = np.array(anni_screen, dtype=np.int64)
-                    create_idx = np.array(create_idx, dtype=np.int64)
+                    a_string = np.array(create_idx + anni_idx, dtype=int)
+                    anni_screen = np.array(anni_screen, dtype=int)
+                    create_idx = np.array(create_idx, dtype=int)
                     tmp_state = apply_operator_threaded(
                         new_state,
                         a_string,
@@ -609,10 +609,10 @@ def propagate_state(
                     for idx in create_idx:
                         if idx not in anni_idx:
                             create_screen.append(idx)
-                    a_string = np.array(anni_idx + create_idx, dtype=np.int64)
-                    create_screen = np.array(create_screen, dtype=np.int64)
-                    create_idx = np.array(create_idx, dtype=np.int64)
-                    anni_idx = np.array(anni_idx, dtype=np.int64)
+                    a_string = np.array(anni_idx + create_idx, dtype=int)
+                    create_screen = np.array(create_screen, dtype=int)
+                    create_idx = np.array(create_idx, dtype=int)
+                    anni_idx = np.array(anni_idx, dtype=int)
                     tmp_state = apply_operator_serial(
                         new_state,
                         a_string,
@@ -674,9 +674,9 @@ def propagate_state_SA(
     else:
         is_parallel = True
     new_state = np.copy(state)
-    tmp_state = np.zeros_like(state, dtype=np.float64)
+    tmp_state = np.zeros_like(state, dtype=float)
     # Create bitstrings for parity check. Contains occupied determinant up to orbital index.
-    parity_check = np.zeros(2 * num_active_orbs + 1, dtype=np.int64)
+    parity_check = np.zeros(2 * num_active_orbs + 1, dtype=int)
     num = 0
     for i in range(2 * num_active_orbs - 1, -1, -1):
         num += 2**i
@@ -727,9 +727,9 @@ def propagate_state_SA(
                     for idx in anni_idx:
                         if idx not in create_idx:
                             anni_screen.append(idx)
-                    a_string = np.array(create_idx + anni_idx, dtype=np.int64)
-                    anni_screen = np.array(anni_screen, dtype=np.int64)
-                    create_idx = np.array(create_idx, dtype=np.int64)
+                    a_string = np.array(create_idx + anni_idx, dtype=int)
+                    anni_screen = np.array(anni_screen, dtype=int)
+                    create_idx = np.array(create_idx, dtype=int)
                     tmp_state = apply_operator_SA_threaded(
                         new_state,
                         a_string,
@@ -760,10 +760,10 @@ def propagate_state_SA(
                     for idx in create_idx:
                         if idx not in anni_idx:
                             create_screen.append(idx)
-                    a_string = np.array(anni_idx + create_idx, dtype=np.int64)
-                    create_screen = np.array(create_screen, dtype=np.int64)
-                    create_idx = np.array(create_idx, dtype=np.int64)
-                    anni_idx = np.array(anni_idx, dtype=np.int64)
+                    a_string = np.array(anni_idx + create_idx, dtype=int)
+                    create_screen = np.array(create_screen, dtype=int)
+                    create_idx = np.array(create_idx, dtype=int)
+                    anni_idx = np.array(anni_idx, dtype=int)
                     tmp_state = apply_operator_SA_serial(
                         new_state,
                         a_string,

--- a/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import copy
 import time
-from collections.abc import Sequence
 from functools import partial
 from typing import Any
 
@@ -39,18 +39,19 @@ from slowquant.unitary_coupled_cluster.util import UpsStructure
 class WaveFunctionSAUPS:
     def __init__(
         self,
-        cas: Sequence[int],
+        active_space: tuple[int, int] | tuple[tuple[int, int], int],
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         states: tuple[list[list[float]], list[list[str]]],
         ansatz: str,
         ansatz_options: dict[str, Any] | None = None,
-        include_active_kappa: bool = False,
+        include_active_kappa: bool = True,
+        resolve_unpaired_idx: str = "both",
     ) -> None:
         """Initialize for SA-UPS wave function.
 
         Args:
-            cas: CAS(num_active_elec, num_active_orbs),
+            active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
                  orbitals are counted in spatial basis.
             mo_coeffs: Initial orbital coefficients.
             integral_generator: Integral generator object.
@@ -60,153 +61,161 @@ class WaveFunctionSAUPS:
             ansatz: Name of ansatz.
             ansatz_options: Ansatz options.
             include_active_kappa: Include active-active orbital rotations.
+            resolve_unpaired_idx: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                  'both', include spatial index in both occ and unocc idx list.
+                                  'occ', include spatial index only in occ idx list.
+                                  'unocc', include spatial index only in unocc idx list.
         """
         if ansatz_options is None:
             ansatz_options = {}
-        if len(cas) != 2:
-            raise ValueError(f"cas must have two elements, got {len(cas)} elements.")
+        self.ansatz_options = copy.deepcopy(ansatz_options)
+        if len(active_space) != 2:
+            raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
+        if isinstance(active_space[0], int):
+            if active_space[0] % 2 == 0:
+                cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
+            else:
+                # Odd number of electrons mean one electron must be unpaired.
+                cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
+        else:
+            cas = ((active_space[0][0], active_space[0][1]), active_space[1])
         # Init stuff
         self.int_gen = IntegralManager(integral_generator)
-        self._c_mo = mo_coeffs
-        self.inactive_spin_idx = []
-        self.virtual_spin_idx = []
-        self.active_spin_idx = []
-        self.active_occ_spin_idx = []
-        self.active_unocc_spin_idx = []
-        self.active_spin_idx_shifted = []
-        self.active_occ_spin_idx_shifted = []
-        self.active_unocc_spin_idx_shifted = []
-        self.active_idx_shifted = []
-        self.active_occ_idx_shifted = []
-        self.active_unocc_idx_shifted = []
-        self.num_spin_orbs = 2 * len(self.int_gen.kinetic_energy)
-        self.num_orbs = len(self.int_gen.kinetic_energy)
-        self.num_active_elec = 0
-        self.num_active_spin_orbs = 0
-        self.num_inactive_spin_orbs = 0
-        self.num_virtual_spin_orbs = 0
+        if np.sum(cas[0]) > self.int_gen.num_elec:
+            raise ValueError("More active electrons than total number electrons.")
+        if (np.sum(cas[0]) % 2 == 0 and self.int_gen.num_elec % 2 == 1) or (
+            np.sum(cas[0]) % 2 == 1 and self.int_gen.num_elec % 2 == 0
+        ):
+            raise ValueError("Specified CAS gives odd number of electrons in inactive space.")
+        self.num_inactive_spin_orbs = self.int_gen.num_elec - int(np.sum(cas[0]))
+        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
+        self.num_active_orbs = cas[1]
+        self.num_active_spin_orbs = 2 * self.num_active_orbs
+        self.num_active_orbs = self.num_active_spin_orbs // 2
+        self.num_virtual_orbs = (
+            len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
+        )
+        if self.num_virtual_orbs < 0:
+            raise ValueError(
+                "Number of inactive + number of active orbitals is larger than total number of orbitals."
+            )
+        self.num_virtual_spin_orbs = 2 * self.num_virtual_orbs
+        self.num_orbs = self.num_inactive_orbs + self.num_active_orbs + self.num_virtual_orbs
+        self.num_spin_orbs = 2 * self.num_orbs
+        self.num_active_elec_alpha = cas[0][0]
+        self.num_active_elec_beta = cas[0][1]
+        self.num_active_elec = self.num_active_elec_alpha + self.num_active_elec_beta
         self._rdm1 = None
         self._rdm2 = None
         self._h_mo = None
         self._g_mo = None
         self._sa_energy: float | None = None
         self._state_energies = None
-        self.ansatz_options = ansatz_options
         self.num_energy_evals = 0
-        # Used when converting to circuit wavefunction.
-        self._include_active_kappa = include_active_kappa
-        self._states = states
-        # Construct spin orbital spaces and indices
-        active_space = []
-        orbital_counter = 0
-        num_elec = self.int_gen.num_elec
-        for i in range(num_elec - cas[0], num_elec):
-            active_space.append(i)
-            orbital_counter += 1
-        for i in range(num_elec, num_elec + 2 * cas[1] - orbital_counter):
-            active_space.append(i)
-        for i in range(num_elec):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_occ_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-                self.num_active_elec += 1
+        self._c_mo = mo_coeffs
+        # Construct spin orbital idx
+        self.inactive_spin_idx = [x for x in range(self.num_inactive_spin_orbs)]
+        self.active_spin_idx = [x + self.num_inactive_spin_orbs for x in range(self.num_active_spin_orbs)]
+        self.virtual_spin_idx = [
+            x + self.num_inactive_spin_orbs + self.num_active_spin_orbs
+            for x in range(self.num_virtual_spin_orbs)
+        ]
+        self.active_occ_spin_idx = []
+        self.active_unocc_spin_idx = []
+        for i, orb_idx in enumerate(self.active_spin_idx):
+            n_ones = 0
+            n_zeros = 0
+            for state in states[1]:
+                for det in state:
+                    if det[i] == "1":
+                        n_ones += 1
+                    else:
+                        n_zeros += 1
+            if n_zeros == 0:
+                # Always occupied in reference
+                self.active_occ_spin_idx.append(orb_idx)
+            elif n_ones == 0:
+                # Always unoccupied in refence
+                self.active_unocc_spin_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "both":
+                self.active_occ_spin_idx.append(orb_idx)
+                self.active_unocc_spin_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "occ":
+                self.active_occ_spin_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "unocc":
+                self.active_unocc_spin_idx.append(orb_idx)
             else:
-                self.inactive_spin_idx.append(i)
-                self.num_inactive_spin_orbs += 1
-        for i in range(num_elec, self.num_spin_orbs):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_unocc_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-            else:
-                self.virtual_spin_idx.append(i)
-                self.num_virtual_spin_orbs += 1
-        if self.num_active_elec % 2 != 0:
-            raise ValueError("Number of active electrons has to be even")
-        self.num_active_elec_alpha = self.num_active_elec // 2
-        self.num_active_elec_beta = self.num_active_elec // 2
-        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
-        self.num_active_orbs = self.num_active_spin_orbs // 2
-        self.num_virtual_orbs = self.num_virtual_spin_orbs // 2
+                raise ValueError(
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                )
+        self.active_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_spin_idx]
+        self.active_occ_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_occ_spin_idx]
+        self.active_unocc_spin_idx_shifted = [
+            x - self.num_inactive_spin_orbs for x in self.active_unocc_spin_idx
+        ]
         # Construct spatial idx
-        self.inactive_idx: list[int] = []
-        self.virtual_idx: list[int] = []
-        self.active_idx: list[int] = []
-        self.active_occ_idx: list[int] = []
-        self.active_unocc_idx: list[int] = []
-        for idx in self.inactive_spin_idx:
-            if idx // 2 not in self.inactive_idx:
-                self.inactive_idx.append(idx // 2)
-        for idx in self.active_spin_idx:
-            if idx // 2 not in self.active_idx:
-                self.active_idx.append(idx // 2)
-        for idx in self.virtual_spin_idx:
-            if idx // 2 not in self.virtual_idx:
-                self.virtual_idx.append(idx // 2)
-        for idx in self.active_occ_spin_idx:
-            if idx // 2 not in self.active_occ_idx:
-                self.active_occ_idx.append(idx // 2)
-        for idx in self.active_unocc_spin_idx:
-            if idx // 2 not in self.active_unocc_idx:
-                self.active_unocc_idx.append(idx // 2)
-        # Make shifted indices
-        if len(self.active_spin_idx) != 0:
-            active_shift = np.min(self.active_spin_idx)
-            for active_idx in self.active_spin_idx:
-                self.active_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_spin_idx:
-                self.active_occ_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_spin_idx:
-                self.active_unocc_spin_idx_shifted.append(active_idx - active_shift)
-        if len(self.active_idx) != 0:
-            active_shift = np.min(self.active_idx)
-            for active_idx in self.active_idx:
-                self.active_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_idx:
-                self.active_occ_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_idx:
-                self.active_unocc_idx_shifted.append(active_idx - active_shift)
+        self.inactive_idx = [x for x in range(self.num_inactive_orbs)]
+        self.active_idx = [x + self.num_inactive_orbs for x in range(self.num_active_orbs)]
+        self.virtual_idx = [
+            x + self.num_inactive_orbs + self.num_active_orbs for x in range(self.num_virtual_orbs)
+        ]
+        self.active_occ_idx = []
+        self.active_unocc_idx = []
+        for i, orb_idx in enumerate(self.active_idx):
+            n_ones = 0
+            n_zeros = 0
+            for state in states[1]:
+                for det in state:
+                    if det[2 * i] == "1" and det[2 * i + 1] == "1":
+                        n_ones += 1
+                    elif det[2 * i] == "0" and det[2 * i + 1] == "0":
+                        n_zeros += 1
+                    else:
+                        n_zeros += 1
+                        n_ones += 1
+            if n_zeros == 0:
+                # Always occupied in reference
+                self.active_occ_idx.append(orb_idx)
+            elif n_ones == 0:
+                # Always unoccupied in refence
+                self.active_unocc_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "both":
+                self.active_occ_idx.append(orb_idx)
+                self.active_unocc_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "occ":
+                self.active_occ_idx.append(orb_idx)
+            elif resolve_unpaired_idx == "unocc":
+                self.active_unocc_idx.append(orb_idx)
+            else:
+                raise ValueError(
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                )
+        self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
+        self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
+        self.active_unocc_idx_shifted = [x - self.num_inactive_orbs for x in self.active_unocc_idx]
         # Find non-redundant kappas
         self._kappa = []
         kappa_idx = []
         kappa_idx_dagger = []
-        kappa_redundant_idx = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
-        # Loop over all q>p orb combinations and find redundant kappas
+        # Loop over all q>p orb combinations.
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
                 # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
                 if not include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
-                        kappa_redundant_idx.append((p, q))
                         continue
                 # the rest is non-redundant
                 self._kappa.append(0.0)
                 self._kappa_old.append(0.0)
                 kappa_idx.append((p, q))
                 kappa_idx_dagger.append((q, p))
-        # HF like orbital rotation indices
-        kappa_hf_like_idx = []
-        for p in range(0, self.num_orbs):
-            for q in range(p + 1, self.num_orbs):
-                if p in self.inactive_idx and q in self.virtual_idx:
-                    kappa_hf_like_idx.append((p, q))
-                elif p in self.inactive_idx and q in self.active_unocc_idx:
-                    kappa_hf_like_idx.append((p, q))
-                elif p in self.active_occ_idx and q in self.virtual_idx:
-                    kappa_hf_like_idx.append((p, q))
         self.kappa_idx = np.array(kappa_idx, dtype=int)
-        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=int)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         # Construct determinant basis
         self.ci_info = get_indexing(
             self.num_inactive_orbs,
@@ -246,23 +255,21 @@ class WaveFunctionSAUPS:
         # Construct UPS Structure
         self.ups_layout = UpsStructure()
         if ansatz.lower() in ("tups", "qnp"):
-            if self.ansatz_options.get("do_pp"):
-                raise ValueError("perfect pairing is not supported for Ansatz in SA UPS wave functions.")
             if ansatz.lower() == "tups":
                 self.ansatz_options["do_tups"] = True
             elif ansatz.lower() == "qnp":
                 self.ansatz_options["do_qnp"] = True
             self.ups_layout.create_tiled(self.num_active_orbs, self.ansatz_options)
         elif ansatz.lower() in ("fucc", "ksafupccgsd", "safuccsd"):
+            self.ansatz_options.setdefault("excitations", [])
             if ansatz.lower() == "ksafupccgsd":
-                self.ansatz_options["SAGS"] = True
-                self.ansatz_options["GpD"] = True
+                self.ansatz_options["excitations"].append("SAGS")
+                self.ansatz_options["excitations"].append("GpD")
             elif ansatz.lower() == "safuccsd":
-                self.ansatz_options["SAS"] = True
-                self.ansatz_options["SAD"] = True
-            if "n_layers" not in self.ansatz_options.keys():
-                # default option
-                self.ansatz_options["n_layers"] = 1
+                self.ansatz_options["excitations"].append("SAS")
+                self.ansatz_options["excitations"].append("SAD")
+            # Default options
+            self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_fUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -272,10 +279,10 @@ class WaveFunctionSAUPS:
                 self.ansatz_options,
             )
         elif ansatz.lower() == "ksasdsfupccgsd":
-            self.ansatz_options["GpD"] = True
-            if "n_layers" not in self.ansatz_options.keys():
-                # default option
-                self.ansatz_options["n_layers"] = 1
+            self.ansatz_options.setdefault("excitations", [])
+            self.ansatz_options["excitations"].append("GpD")
+            # Default options
+            self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_SDSfUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -287,6 +294,10 @@ class WaveFunctionSAUPS:
         else:
             raise ValueError(f"Got unknown ansatz, {ansatz}")
         self._thetas = np.zeros(self.ups_layout.n_params).tolist()
+        # Used when converting to circuit wavefunction.
+        self._include_active_kappa = include_active_kappa
+        self._states = states
+        self._resolve_unpaired_idx = resolve_unpaired_idx
 
     @property
     def kappa(self) -> list[float]:
@@ -402,7 +413,7 @@ class WaveFunctionSAUPS:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs))
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_idx = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -437,7 +448,8 @@ class WaveFunctionSAUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_idx = p - self.num_inactive_orbs
@@ -478,16 +490,13 @@ class WaveFunctionSAUPS:
                             self._rdm2[s_idx, r_idx, q_idx, p_idx] = val  # type: ignore
         return self._rdm2
 
-    def check_orthonormality(self, overlap_integral: np.ndarray) -> None:
+    def check_orthonormality(self) -> None:
         r"""Check orthonormality of orbitals.
 
         .. math::
             \boldsymbol{I} = \boldsymbol{C}_\text{MO}\boldsymbol{S}\boldsymbol{C}_\text{MO}^T
-
-        Args:
-            overlap_integral: Overlap integral in AO basis.
         """
-        S_ortho = one_electron_integral_transform(self.c_mo, overlap_integral)
+        S_ortho = one_electron_integral_transform(self.c_mo, self.int_gen.overlap)
         one = np.identity(len(S_ortho))
         diff = np.abs(S_ortho - one)
         print("Max ortho-normal diff:", np.max(diff))
@@ -514,33 +523,78 @@ class WaveFunctionSAUPS:
             )
         return self._sa_energy
 
-    def run_wf_optimization_2step(
+    def run_wf_optimization(
         self,
-        optimizer_name: str,
-        orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
+        orbital_optimization: bool = False,
+        theta_optimization: bool = True,
+        one_step_optimizer: str = "BFGS",
+        theta_optimizer: str = "BFGS",
+        orbital_optimizer: str = "BFGS",
+        opt_type: str = "1step",
         is_silent_subiterations: bool = False,
     ) -> None:
-        """Run two step optimization of wave function.
+        """Run variational optimization of wavefunction.
 
         Args:
-            optimizer_name: Name of optimizer.
-            orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
+            tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            is_silent_subiterations: Silence subiterations.
+            orbital_optimization: Perform orbital optimization.
+            theta_optimization: Perform theta optimization.
+            one_step_optimizer: Optimizer used for 1step optimizer.
+            theta_optimizer: Optimizer used for theta optimization in 2step optimizer.
+            orbital_optimizer: Optimizer used for orbital optimization in 2step optimizer.
+            opt_type: Optimization type, can be '1step' or '2step'.
+            is_silent_subiterations: Silence sub iterations in 2step.
         """
+        if len(self.kappa) == 0 and orbital_optimization:
+            print("No kappa parameters turning off orbital optimization.")
+            orbital_optimization = False
+        if len(self.thetas) == 0 and theta_optimization:
+            print("No thetas parameters turning off theta optimization.")
+            theta_optimization = False
+        if opt_type.lower() == "2step" and (not orbital_optimization or not theta_optimization):
+            if not orbital_optimization:
+                print("Orbital optimization not requested changing optimizer type to 1step.")
+                opt_type = "1step"
+            elif not theta_optimization:
+                print("theta optimization not requested changing optimizer type to 1step.")
+                opt_type = "1step"
         print("### Parameters information:")
         if orbital_optimization:
             print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {self.ups_layout.n_params}")
+        if theta_optimization:
+            print(f"### Number theta: {self.ups_layout.n_params}")
+        if opt_type.lower() == "1step":
+            self._run_wf_optimization_1step(
+                tol, maxiter, orbital_optimization, theta_optimization, one_step_optimizer
+            )
+        elif opt_type.lower() == "2step":
+            self._run_wf_optimization_2step(
+                tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
+            )
+        else:
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
+
+    def _run_wf_optimization_2step(
+        self,
+        tol: float,
+        maxiter: int,
+        theta_optimizer: str,
+        orbital_optimizer: str,
+        is_silent_subiterations: bool,
+    ) -> None:
+        """Run two step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        for full_iter in range(0, int(maxiter)):
+        for full_iter in range(0, maxiter):
             full_start = time.time()
-
             # Do ansatz optimization
             if not is_silent_subiterations:
                 print("--------Ansatz optimization")
@@ -559,7 +613,7 @@ class WaveFunctionSAUPS:
             )
             optimizer = Optimizers(
                 energy_theta,
-                optimizer_name,
+                theta_optimizer,
                 grad=gradient_theta,
                 maxiter=maxiter,
                 tol=tol,
@@ -568,7 +622,7 @@ class WaveFunctionSAUPS:
             )
             self._old_opt_parameters = np.zeros_like(self.thetas) + 10**20
             self._E_opt_old = 0.0
-            if optimizer_name.lower() == "rotosolve":
+            if theta_optimizer.lower() == "rotosolve":
                 res = optimizer.minimize(
                     self.thetas,
                     extra_options={
@@ -583,47 +637,37 @@ class WaveFunctionSAUPS:
                 )
             self.thetas = res.x.tolist()
 
-            if orbital_optimization and len(self.kappa) != 0:
-                if not is_silent_subiterations:
-                    print("--------Orbital optimization")
-                    print(
-                        "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
-                    )
-                energy_oo = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
+            if not is_silent_subiterations:
+                print("--------Orbital optimization")
+                print(
+                    "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
                 )
-                gradient_oo = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
+            energy_oo = partial(
+                self._calc_energy_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
+            gradient_oo = partial(
+                self._calc_gradient_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
 
-                optimizer = Optimizers(
-                    energy_oo,
-                    "l-bfgs-b",
-                    grad=gradient_oo,
-                    maxiter=maxiter,
-                    tol=tol,
-                    is_silent=is_silent_subiterations,
-                    energy_eval_callback=lambda: self.num_energy_evals,
-                )
-                self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
-                self._E_opt_old = 0.0
-                res = optimizer.minimize([0.0] * len(self.kappa_idx))
-                for i in range(len(self.kappa)):
-                    self._kappa[i] = 0.0
-                    self._kappa_old[i] = 0.0
-            else:
-                # If there is no orbital optimization, then the algorithm is already converged.
-                e_new = res.fun
-                if orbital_optimization and len(self.kappa) == 0:
-                    print(
-                        "WARNING: No orbital optimization performed, because there is no non-redundant orbital parameters"
-                    )
-                break
-
+            optimizer = Optimizers(
+                energy_oo,
+                orbital_optimizer,
+                grad=gradient_oo,
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
+                energy_eval_callback=lambda: self.num_energy_evals,
+            )
+            self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
+            self._E_opt_old = 0.0
+            res = optimizer.minimize([0.0] * len(self.kappa_idx))
+            for i in range(len(self.kappa)):
+                self._kappa[i] = 0.0
+                self._kappa_old[i] = 0.0
             e_new = res.fun
             time_str = f"{time.time() - full_start:7.2f}"
             e_str = f"{e_new:3.12f}"
@@ -637,68 +681,36 @@ class WaveFunctionSAUPS:
         self._do_state_ci()
         self._sa_energy = res.fun
 
-    def run_wf_optimization_1step(
+    def _run_wf_optimization_1step(
         self,
-        optimizer_name: str,
-        orbital_optimization: bool = False,
-        tol: float = 1e-10,
-        maxiter: int = 1000,
+        tol: float,
+        maxiter: int,
+        orbital_optimization: bool,
+        theta_optimization: bool,
+        one_step_optimizer: str,
     ) -> None:
         """Run one step optimization of wave function.
 
-        Args:
-            optimizer_name: Name of optimizer.
-            orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
-            maxiter: Maximum number of iterations.
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
         """
-        print("### Parameters information:")
-        if orbital_optimization:
-            print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {self.ups_layout.n_params}")
-        if optimizer_name.lower() == "rotosolve":
-            if orbital_optimization and len(self.kappa) != 0:
-                raise ValueError(
-                    "Cannot use RotoSolve together with orbital optimization in the one-step solver."
-                )
-
+        if one_step_optimizer.lower() == "rotosolve" and orbital_optimization:
+            raise ValueError(
+                "Cannot use RotoSolve together with orbital optimization in the one-step solver."
+            )
         print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
+        energy = partial(
+            self._calc_energy_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        gradient = partial(
+            self._calc_gradient_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
         if orbital_optimization:
-            if len(self.thetas) > 0:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-            else:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-        else:
-            energy = partial(
-                self._calc_energy_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-            gradient = partial(
-                self._calc_gradient_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+            if theta_optimization:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
@@ -706,7 +718,7 @@ class WaveFunctionSAUPS:
             parameters = self.thetas
         optimizer = Optimizers(
             energy,
-            optimizer_name,
+            one_step_optimizer,
             grad=gradient,
             maxiter=maxiter,
             tol=tol,
@@ -714,7 +726,7 @@ class WaveFunctionSAUPS:
         )
         self._old_opt_parameters = np.zeros_like(parameters) + 10**20
         self._E_opt_old = 0.0
-        if optimizer_name.lower() == "rotosolve":
+        if one_step_optimizer.lower() == "rotosolve":
             res = optimizer.minimize(
                 parameters,
                 extra_options={
@@ -728,7 +740,8 @@ class WaveFunctionSAUPS:
                 parameters,
             )
         if orbital_optimization:
-            self.thetas = res.x[len(self.kappa) :].tolist()
+            if theta_optimization:
+                self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0
                 self._kappa_old[i] = 0.0

--- a/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
@@ -203,10 +203,10 @@ class WaveFunctionSAUPS:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=int)
-        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=int)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
+        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
+        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=np.int64)
+        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=np.int64)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
         # Construct determinant basis
         self.ci_info = get_indexing(
             self.num_inactive_orbs,

--- a/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
@@ -91,7 +91,6 @@ class WaveFunctionSAUPS:
         self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
         self.num_active_orbs = cas[1]
         self.num_active_spin_orbs = 2 * self.num_active_orbs
-        self.num_active_orbs = self.num_active_spin_orbs // 2
         self.num_virtual_orbs = (
             len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
         )

--- a/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
@@ -203,10 +203,10 @@ class WaveFunctionSAUPS:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
-        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=np.int64)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=np.int64)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
+        self.kappa_idx = np.array(kappa_idx, dtype=int)
+        self.kappa_idx_dagger = np.array(kappa_idx_dagger, dtype=int)
+        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         # Construct determinant basis
         self.ci_info = get_indexing(
             self.num_inactive_orbs,
@@ -218,7 +218,7 @@ class WaveFunctionSAUPS:
         self.num_det = len(self.ci_info.idx2det)
         # SA details
         self.num_states = len(states[0])
-        self.csf_coeffs = np.zeros((self.num_states, self.num_det))  # state vector for each state in SA
+        self.ref_coeffs = np.zeros((self.num_states, self.num_det))  # state vector for each state in SA
         # Loop over all states in SA procedure
         for i, (coeffs, on_vecs) in enumerate(zip(states[0], states[1])):
             if len(coeffs) != len(on_vecs):
@@ -232,8 +232,8 @@ class WaveFunctionSAUPS:
                         f"Length of determinant, {len(on_vec)}, does not match number of active spin orbitals, {self.num_active_spin_orbs}. For determinant, {on_vec}"
                     )
                 idx = self.ci_info.det2idx[int(on_vec, 2)]
-                self.csf_coeffs[i, idx] = coeff
-        self._ci_coeffs = np.copy(self.csf_coeffs)
+                self.ref_coeffs[i, idx] = coeff
+        self._ci_coeffs = np.copy(self.ref_coeffs)
         for i, coeff_i in enumerate(self.ci_coeffs):
             for j, coeff_j in enumerate(self.ci_coeffs):
                 if i == j:
@@ -319,7 +319,7 @@ class WaveFunctionSAUPS:
         """
         if self._ci_coeffs is None:
             self._ci_coeffs = construct_ups_state_SA(
-                self.csf_coeffs,
+                self.ref_coeffs,
                 self.ci_info,
                 self.thetas,
                 self.ups_layout,
@@ -968,8 +968,8 @@ class WaveFunctionSAUPS:
                 dagger=True,
             )
             # CSF reference state on ket
-            ket_vec = np.copy(self.csf_coeffs)
-            ket_vec_tmp = np.copy(self.csf_coeffs)
+            ket_vec = np.copy(self.ref_coeffs)
+            ket_vec_tmp = np.copy(self.ref_coeffs)
             # Calculate analytical derivative w.r.t. each theta using gradient_action function
             for i in range(len(self.thetas)):
                 # Loop over each state in SA
@@ -1022,7 +1022,7 @@ class WaveFunctionSAUPS:
         thetas_local = np.asarray(parameters)
 
         # Prepare reference state up to theta_idx
-        state_vec = np.copy(self.csf_coeffs)
+        state_vec = np.copy(self.ref_coeffs)
         for i in range(0, theta_idx):
             state_vec = propagate_unitary_SA(
                 state_vec,
@@ -1074,7 +1074,7 @@ class WaveFunctionSAUPS:
         energies = np.zeros(len(theta_diffs))
         idx = -1
         for i, (bra, ket) in enumerate(zip(bra_vec, state_vecs)):
-            if i % len(self.csf_coeffs) == 0:
+            if i % len(self.ref_coeffs) == 0:
                 idx += 1
             energies[idx] += bra @ ket
         self.num_energy_evals += self.num_states  # count one measurement per state

--- a/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
@@ -845,7 +845,7 @@ class WaveFunctionSAUPS:
             transition_property[i] = self._state_ci_coeffs[:, i + 1] @ state_op @ self._state_ci_coeffs[:, 0]
         return transition_property
 
-    def get_oscillator_strenghts(self) -> np.ndarray:
+    def get_oscillator_strengths(self) -> np.ndarray:
         r"""Get oscillator strengths between ground state and excited states.
 
         .. math::

--- a/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/sa_ups_wavefunction.py
@@ -145,7 +145,7 @@ class WaveFunctionSAUPS:
                 self.active_unocc_spin_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, expected 'both', 'occ' or 'unocc'."
                 )
         self.active_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_spin_idx]
         self.active_occ_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_occ_spin_idx]
@@ -187,7 +187,7 @@ class WaveFunctionSAUPS:
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, expected 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -201,7 +201,6 @@ class WaveFunctionSAUPS:
         # Loop over all q>p orb combinations.
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
-                # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
@@ -260,6 +259,8 @@ class WaveFunctionSAUPS:
                 self.ansatz_options["do_qnp"] = True
             self.ups_layout.create_tiled(self.num_active_orbs, self.ansatz_options)
         elif ansatz.lower() in ("fucc", "ksafupccgsd", "safuccsd"):
+            # Default options
+            self.ansatz_options.setdefault("n_layers", 1)
             self.ansatz_options.setdefault("excitations", [])
             if ansatz.lower() == "ksafupccgsd":
                 self.ansatz_options["excitations"].append("SAGS")
@@ -267,8 +268,6 @@ class WaveFunctionSAUPS:
             elif ansatz.lower() == "safuccsd":
                 self.ansatz_options["excitations"].append("SAS")
                 self.ansatz_options["excitations"].append("SAD")
-            # Default options
-            self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_fUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -278,10 +277,10 @@ class WaveFunctionSAUPS:
                 self.ansatz_options,
             )
         elif ansatz.lower() == "ksasdsfupccgsd":
-            self.ansatz_options.setdefault("excitations", [])
-            self.ansatz_options["excitations"].append("GpD")
             # Default options
             self.ansatz_options.setdefault("n_layers", 1)
+            self.ansatz_options.setdefault("excitations", [])
+            self.ansatz_options["excitations"].append("GpD")
             self.ups_layout.create_SDSfUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -315,10 +314,11 @@ class WaveFunctionSAUPS:
         self._sa_energy = None
         self._state_energies = None
         self._kappa = k.copy()
+        if isinstance(self._kappa, np.ndarray):
+            self._kappa = self._kappa.tolist()
         # Move current expansion point.
         self._c_mo = self.c_mo
         self._kappa_old = self.kappa
-        self._state_ci_coeffs = None
 
     @property
     def ci_coeffs(self) -> list[np.ndarray]:
@@ -361,13 +361,15 @@ class WaveFunctionSAUPS:
         self._state_ci_coeffs = None
         self._ci_coeffs = None
         self._thetas = theta_vals.copy()
+        if isinstance(self._thetas, np.ndarray):
+            self._thetas = self._thetas.tolist()
 
     @property
     def c_mo(self) -> np.ndarray:
-        """Get orbital coefficients.
+        """Get molecular orbital coefficients.
 
         Returns:
-            Orbital coefficients.
+            Molecular orbital coefficients.
         """
         # Construct anti-hermitian kappa matrix
         kappa_mat = np.zeros_like(self._c_mo)
@@ -414,23 +416,17 @@ class WaveFunctionSAUPS:
         if self._rdm1 is None:
             self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
-                    val = 0.0
-                    Epq_op = Epq(
-                        p_idx,
-                        q_idx,
-                    )
+                    q_ = q - self.num_inactive_orbs
                     val = expectation_value_SA(
                         self.ci_coeffs,
-                        [Epq_op],
+                        [Epq(p, q)],
                         self.ci_coeffs,
                         self.ci_info,
-                        do_folding=False,
                     )
-                    self._rdm1[p_idx, q_idx] = val  # type: ignore
-                    self._rdm1[q_idx, p_idx] = val  # type: ignore
+                    self._rdm1[p_, q_] = val  # type: ignore
+                    self._rdm1[q_, p_] = val  # type: ignore
         return self._rdm1
 
     @property
@@ -451,15 +447,11 @@ class WaveFunctionSAUPS:
                 dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
-                    Epq_op = Epq(
-                        p_idx,
-                        q_idx,
-                    )
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         if p == q:
                             s_lim = r + 1
                         elif p == r:
@@ -469,24 +461,19 @@ class WaveFunctionSAUPS:
                         else:
                             s_lim = p + 1
                         for s in range(self.num_inactive_orbs, s_lim):
-                            s_idx = s - self.num_inactive_orbs
-                            Ers_op = Epq(
-                                r_idx,
-                                s_idx,
-                            )
+                            s_ = s - self.num_inactive_orbs
                             val = expectation_value_SA(
                                 self.ci_coeffs,
-                                [Epq_op, Ers_op],
+                                [Epq(p, q) * Epq(r, s)],
                                 self.ci_coeffs,
                                 self.ci_info,
-                                do_folding=False,
                             )
                             if q == r:
-                                val -= self.rdm1[p_idx, s_idx]
-                            self._rdm2[p_idx, q_idx, r_idx, s_idx] = val  # type: ignore
-                            self._rdm2[r_idx, s_idx, p_idx, q_idx] = val  # type: ignore
-                            self._rdm2[q_idx, p_idx, s_idx, r_idx] = val  # type: ignore
-                            self._rdm2[s_idx, r_idx, q_idx, p_idx] = val  # type: ignore
+                                val -= self.rdm1[p_, s_]
+                            self._rdm2[p_, q_, r_, s_] = val  # type: ignore
+                            self._rdm2[r_, s_, p_, q_] = val  # type: ignore
+                            self._rdm2[q_, p_, s_, r_] = val  # type: ignore
+                            self._rdm2[s_, r_, q_, p_] = val  # type: ignore
         return self._rdm2
 
     def check_orthonormality(self) -> None:
@@ -574,7 +561,7 @@ class WaveFunctionSAUPS:
                 tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
             )
         else:
-            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} expected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
@@ -877,9 +864,9 @@ class WaveFunctionSAUPS:
             E = \left<0\left|\hat{H}\right|0\right>
 
         Args:
-            parameters: Ansatz and orbital rotation parameters.
-            theta_optimization: If used in theta optimization.
-            kappa_optimization: If used in kappa optimization.
+            parameters: Orbital rotation and ansatz parameters.
+            theta_optimization: Doing theta optimization.
+            kappa_optimization: Doing kappa optimization.
             return_all_states: Return the energy for all states instead of only the averaged energy.
 
         Returns:
@@ -936,8 +923,8 @@ class WaveFunctionSAUPS:
 
         Args:
             parameters: Ansatz and orbital rotation parameters.
-            theta_optimization: If used in theta optimization.
-            kappa_optimization: If used in kappa optimization.
+            theta_optimization: Doing theta optimization.
+            kappa_optimization: Doing kappa optimization.
 
         Returns:
             State-averaged electronic gradient.

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -97,7 +97,7 @@ class WaveFunctionUCC:
             if active_space[0] % 2 == 0:
                 cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
             else:
-                # Uneven number of electrons mean one electron must be unpaired.
+                # Odd number of electrons mean one electron must be unpaired.
                 cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
         else:
             cas = ((active_space[0][0], active_space[0][1]), active_space[1])
@@ -219,10 +219,9 @@ class WaveFunctionUCC:
         kappa_no_activeactive_idx_dagger = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
-        # Loop over all q>p orb combinations and find redundant kappas
+        # Loop over all q>p orb combinations
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
-                # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -84,7 +84,7 @@ class WaveFunctionUCC:
             "reference_determiant",
         )
         for option in wavefunction_options:
-            if option not in wavefunction_options:
+            if option not in valid_options:
                 raise ValueError(
                     f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
                 )

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import copy
 import time
 from functools import partial
-from typing import Any
 
 import numpy as np
 import pyscf
@@ -40,20 +38,11 @@ class WaveFunctionUCC:
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         excitations: list[str],
-        wavefunction_options: dict[str, Any] | None = None,
+        reference_determinant: str | None = None,
+        include_active_kappa: bool = True,
+        resolve_unpaired_idx: str = "both",
     ) -> None:
         """Initialize for UCC wave function.
-
-        Wavefunction Options:
-            * include_active_kappa [bool]: Include active-active orbital rotations.
-                                           (default: True)
-            * resolve_unpaired_idx [str]: Specify how to resolve spatial index with respect to occupation of reference determinant.
-                                          'both', include spatial index in both occ and unocc idx list.
-                                          'occ', include spatial index only in occ idx list.
-                                          'unocc', include spatial index only in unocc idx list.
-                                          (default: 'both')
-            * reference_determinant [str]: Specify a reference determinant for the active space part.
-                                          1 specifying occupied orbital and 0 specifying unoccupied orbital.
 
         Possible excitations:
             * S: Add single excitations.
@@ -73,24 +62,14 @@ class WaveFunctionUCC:
             mo_coeffs: Initial orbital coefficients.
             integral_generator: Integral generator object.
             excitations: Unitary coupled cluster excitation operators.
-            wavefunction_options: Wavefunction options.
+            reference_determinant: Specify a reference determinant for the active space part.
+                                   1 specifying occupied orbital and 0 specifying unoccupied orbital.
+            include_active_kappa: Include active-active orbital rotations.
+            resolve_unpaired_idx: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                  'both', include spatial index in both occ and unocc idx list.
+                                  'occ', include spatial index only in occ idx list.
+                                  'unocc', include spatial index only in unocc idx list.
         """
-        if wavefunction_options is None:
-            wavefunction_options = {}
-        self.wavefunction_options = copy.deepcopy(wavefunction_options)
-        valid_options = (
-            "resolve_unpaired_idx",
-            "include_active_kappa",
-            "reference_determinant",
-        )
-        for option in wavefunction_options:
-            if option not in valid_options:
-                raise ValueError(
-                    f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
-                )
-        # Default options
-        self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
-        self.wavefunction_options.setdefault("include_active_kappa", True)
         if len(active_space) != 2:
             raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
         if isinstance(active_space[0], int):
@@ -136,15 +115,15 @@ class WaveFunctionUCC:
         self._energy_elec: float | None = None
         self._c_mo = mo_coeffs
         # Reference wave function
-        if "reference_determinant" in self.wavefunction_options.keys():
-            ref_det = self.wavefunction_options["reference_determinant"]
+        if reference_determinant is not None:
+            ref_det = reference_determinant
             if len(ref_det) != self.num_active_spin_orbs:
                 raise ValueError(
                     f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
                 )
             ref_alpha = 0
             ref_beta = 0
-            for i, idx in ref_det:
+            for i, idx in enumerate(ref_det):
                 if i % 2 == 0 and idx == "1":
                     ref_alpha += 1
                 elif idx == "1":
@@ -196,16 +175,16 @@ class WaveFunctionUCC:
                 self.active_occ_idx.append(orb_idx)
             elif ref_det[2 * i] == "0" and ref_det[2 * i + 1] == "0":
                 self.active_unocc_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "both":
+            elif resolve_unpaired_idx == "both":
                 self.active_occ_idx.append(orb_idx)
                 self.active_unocc_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
+            elif resolve_unpaired_idx == "occ":
                 self.active_occ_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
+            elif resolve_unpaired_idx == "unocc":
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, expected 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -224,7 +203,7 @@ class WaveFunctionUCC:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
                     continue
-                if not self.wavefunction_options["include_active_kappa"]:
+                if not include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
                         continue
                 if not (p in self.active_idx and q in self.active_idx):
@@ -260,7 +239,7 @@ class WaveFunctionUCC:
         self.ref_coeffs = np.zeros(self.num_det, dtype=float)
         print("Reference (active) determinant:", ref_det)
         self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
-        self.ci_coeffs = np.copy(self.ref_coeffs)
+        self._ci_coeffs = np.copy(self.ref_coeffs)
         # Construct UCC Structure
         self.ucc_layout = UccStructure()
         self.ucc_layout.add_excitations(
@@ -296,6 +275,22 @@ class WaveFunctionUCC:
         self._kappa_old = self.kappa
 
     @property
+    def ci_coeffs(self) -> np.ndarray:
+        """Get CI coefficients.
+
+        Returns:
+            State vector.
+        """
+        if self._ci_coeffs is None:
+            self._ci_coeffs = construct_ucc_state(
+                self.ref_coeffs,
+                self.ci_info,
+                self.thetas,
+                self.ucc_layout,
+            )
+        return self._ci_coeffs
+
+    @property
     def thetas(self) -> list[float]:
         """Get theta values.
 
@@ -318,13 +313,8 @@ class WaveFunctionUCC:
         self._rdm3 = None
         self._rdm4 = None
         self._energy_elec = None
+        self._ci_coeffs = None
         self._thetas = theta.copy()
-        self.ci_coeffs = construct_ucc_state(
-            self.ref_coeffs,
-            self.ci_info,
-            self.thetas,
-            self.ucc_layout,
-        )
 
     @property
     def c_mo(self) -> np.ndarray:
@@ -658,83 +648,46 @@ class WaveFunctionUCC:
 
     def run_wf_optimization(
         self,
-        orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
-        optimization_options: dict[str, Any] | None = None,
+        orbital_optimization: bool = False,
+        theta_optimization: bool = True,
+        one_step_optimizer: str = "BFGS",
+        theta_optimizer: str = "BFGS",
+        orbital_optimizer: str = "BFGS",
+        opt_type: str = "1step",
+        is_silent_subiterations: bool = False,
     ) -> None:
         """Run variational optimization of wavefunction.
 
-        Optimization options:
-            * theta_optimization [bool]: Perform theta optimization.
-                                         (default: True)
-            * theta_optimizer [str]: Optimizer used for theta optimization.
-                                     (default: BFGS)
-            * orbital_optimizer [str]: Optimizer used for orbital optimization.
-                                     (default: BFGS)
-            * 1step_optimizer [str]: Optimizer used for 1step optimizer.
-                                     (fallback: copy theta_optimizer)
-            * opt_type [str]: Optimization type, can be '1step' or '2step'.
-                              (default: 1step)
-            * is_silent_subiterations [bool]: Silence sub iterations in 2step.
-                                              (default: False)
-
         Args:
-            orbital_optimization: Perform orbital optimization.
             tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            optimization_options: Additional optimization options.
+            orbital_optimization: Perform orbital optimization.
+            theta_optimization: Perform theta optimization.
+            one_step_optimizer: Optimizer used for 1step optimizer.
+            theta_optimizer: Optimizer used for theta optimization in 2step optimizer.
+            orbital_optimizer: Optimizer used for orbital optimization in 2step optimizer.
+            opt_type: Optimization type, can be '1step' or '2step'.
+            is_silent_subiterations: Silence sub iterations in 2step.
         """
-        if optimization_options is None:
-            optimization_options = {}
-        self._optimization_options = copy.deepcopy(optimization_options)
-        valid_options = (
-            "theta_optimization",
-            "theta_optimizer",
-            "orbital_optimizer",
-            "opt_type",
-            "is_silent_subiterations",
-            "1step_optimizer",
-        )
-        for option in self._optimization_options:
-            if option not in valid_options:
-                raise ValueError(
-                    f"Got unknown option for optimization, {option}. Valid options are: {valid_options}"
-                )
-        self._optimization_options["tol"] = tol
-        self._optimization_options["maxiter"] = int(maxiter)
-        self._optimization_options["orbital_optimization"] = orbital_optimization
-        self._optimization_options.setdefault("theta_optimization", True)
-        self._optimization_options.setdefault("theta_optimizer", "BFGS")
-        self._optimization_options.setdefault("orbital_optimizer", "BFGS")
-        self._optimization_options.setdefault("opt_type", "1step")
-        self._optimization_options.setdefault("is_silent_subiterations", False)
-        if len(self.kappa) == 0 and self._optimization_options["orbital_optimization"]:
+        if len(self.kappa) == 0 and orbital_optimization:
             print("No kappa parameters turning off orbital optimization.")
-        if len(self.thetas) == 0 and self._optimization_options["theta_optimization"]:
+            orbital_optimization = False
+        if len(self.thetas) == 0 and theta_optimization:
             print("No thetas parameters turning off theta optimization.")
-        if self._optimization_options["opt_type"].lower() == "2step" and (
-            not self._optimization_options["orbital_optimization"]
-            or not self._optimization_options["theta_optimization"]
-        ):
-            if not self._optimization_options["orbital_optimization"]:
+            theta_optimization = False
+        if opt_type.lower() == "2step" and (not orbital_optimization or not theta_optimization):
+            if not orbital_optimization:
                 print("Orbital optimization not requested changing optimizer type to 1step.")
-                self._optimization_options["opt_type"] = "1step"
-            elif not self._optimization_options["theta_optimization"]:
+                opt_type = "1step"
+            elif not theta_optimization:
                 print("theta optimization not requested changing optimizer type to 1step.")
-                self._optimization_options["opt_type"] = "1step"
-        if (
-            self._optimization_options["opt_type"].lower() == "1step"
-            and "1step_optimizer" not in self._optimization_options.keys()
-        ):
-            print(
-                f"'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
-            )
-            self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
+                opt_type = "1step"
         print("### Parameters information:")
-        if self._optimization_options["orbital_optimization"]:
+        if orbital_optimization:
             print(f"### Number kappa: {len(self.kappa)}")
-        if self._optimization_options["theta_optimization"]:
+        if theta_optimization:
             num_theta1 = 0
             num_theta2 = 0
             num_theta3 = 0
@@ -770,26 +723,37 @@ class WaveFunctionUCC:
                 print(f"### Number theta4: {num_theta4}")
                 print(f"### Number theta5: {num_theta5}")
                 print(f"### Number theta6: {num_theta6}")
-        if self._optimization_options["opt_type"].lower() == "1step":
-            self._run_wf_optimization_1step()
-        elif self._optimization_options["opt_type"].lower() == "2step":
-            self._run_wf_optimization_2step()
-        else:
-            raise ValueError(
-                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."
+        if opt_type.lower() == "1step":
+            self._run_wf_optimization_1step(
+                tol, maxiter, orbital_optimization, theta_optimization, one_step_optimizer
             )
+        elif opt_type.lower() == "2step":
+            self._run_wf_optimization_2step(
+                tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
+            )
+        else:
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
+        tol: float,
+        maxiter: int,
+        theta_optimizer: str,
+        orbital_optimizer: str,
+        is_silent_subiterations: bool,
     ) -> None:
-        """Run two step optimization of wave function."""
+        """Run two step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree]")
-        for full_iter in range(0, self._optimization_options["maxiter"]):
+        for full_iter in range(0, maxiter):
             full_start = time.time()
             # Do ansatz optimization
-            if not self._optimization_options["is_silent_subiterations"]:
+            if not is_silent_subiterations:
                 print("--------UCC optimization")
                 print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree]")
             energy_theta = partial(
@@ -804,18 +768,18 @@ class WaveFunctionUCC:
             )
             optimizer = Optimizers(
                 energy_theta,
-                self._optimization_options["theta_optimizer"],
+                theta_optimizer,
                 grad=gradient_theta,
-                maxiter=self._optimization_options["maxiter"],
-                tol=self._optimization_options["tol"],
-                is_silent=self._optimization_options["is_silent_subiterations"],
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
             )
             self._old_opt_parameters = np.zeros_like(self.thetas) + 10**20
             self._E_opt_old = 0.0
             res = optimizer.minimize(self.thetas)
             self.thetas = res.x.tolist()
 
-            if not self._optimization_options["is_silent_subiterations"]:
+            if not is_silent_subiterations:
                 print("--------Orbital optimization")
                 print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree]")
             energy_oo = partial(
@@ -831,11 +795,11 @@ class WaveFunctionUCC:
 
             optimizer = Optimizers(
                 energy_oo,
-                self._optimization_options["orbital_optimizer"],
+                orbital_optimizer,
                 grad=gradient_oo,
-                maxiter=self._optimization_options["maxiter"],
-                tol=self._optimization_options["tol"],
-                is_silent=self._optimization_options["is_silent_subiterations"],
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
             )
             self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
             self._E_opt_old = 0.0
@@ -847,52 +811,37 @@ class WaveFunctionUCC:
             time_str = f"{time.time() - full_start:7.2f}"
             e_str = f"{e_new:3.12f}"
             print(f"{str(full_iter + 1).center(11)} | {time_str.center(18)} | {e_str.center(27)}")
-            if abs(e_new - e_old) < self._optimization_options["tol"]:
+            if abs(e_new - e_old) < tol:
                 break
             e_old = e_new
         self._energy_elec = e_new
 
     def _run_wf_optimization_1step(
         self,
+        tol: float,
+        maxiter: int,
+        orbital_optimization: bool,
+        theta_optimization: bool,
+        one_step_optimizer: str,
     ) -> None:
-        """Run one step optimization of wave function."""
-        print("Iteration # | Iteration time [s] | Electronic energy [Hartree]")
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-            else:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-        else:
-            energy = partial(
-                self._calc_energy_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-            gradient = partial(
-                self._calc_gradient_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
+        """Run one step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
+        print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree]")
+        energy = partial(
+            self._calc_energy_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        gradient = partial(
+            self._calc_gradient_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        if orbital_optimization:
+            if theta_optimization:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
@@ -900,16 +849,16 @@ class WaveFunctionUCC:
             parameters = self.thetas
         optimizer = Optimizers(
             energy,
-            self._optimization_options["1step_optimizer"],
+            one_step_optimizer,
             grad=gradient,
-            maxiter=self._optimization_options["maxiter"],
-            tol=self._optimization_options["tol"],
+            maxiter=maxiter,
+            tol=tol,
         )
         self._old_opt_parameters = np.zeros_like(parameters) + 10**20
         self._E_opt_old = 0.0
         res = optimizer.minimize(parameters)
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
+        if orbital_optimization:
+            if theta_optimization:
                 self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -92,7 +92,6 @@ class WaveFunctionUCC:
         self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
         self.num_active_orbs = cas[1]
         self.num_active_spin_orbs = 2 * self.num_active_orbs
-        self.num_active_orbs = self.num_active_spin_orbs // 2
         self.num_virtual_orbs = (
             len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
         )

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import copy
 import time
-from collections.abc import Sequence
 from functools import partial
+from typing import Any
 
 import numpy as np
 import pyscf
@@ -35,45 +36,97 @@ from slowquant.unitary_coupled_cluster.util import UccStructure
 class WaveFunctionUCC:
     def __init__(
         self,
-        cas: Sequence[int],
+        active_space: tuple[int, int] | tuple[tuple[int, int], int],
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
-        excitations: str,
-        include_active_kappa: bool = False,
+        excitations: list[str],
+        wavefunction_options: dict[str, Any] | None = None,
     ) -> None:
         """Initialize for UCC wave function.
 
+        Wavefunction Options:
+            * include_active_kappa [bool]: Include active-active orbital rotations.
+                                           (default: True)
+            * resolve_unpaired_idx [str]: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                          'both', include spatial index in both occ and unocc idx list.
+                                          'occ', include spatial index only in occ idx list.
+                                          'unocc', include spatial index only in unocc idx list.
+                                          (default: 'both')
+            * reference_determiant [str]: Specify a reference determinant for the active space part.
+                                          1 specifying occupied orbital and 0 specifying unoccupied orbital.
+
+        Possible excitations:
+            * S: Add single excitations.
+            * GS: Add generalized single excitations.
+            * SAS: Add spin-adapted single excitations.
+            * SAGS: Add generalized spin-adapted single excitations.
+            * D: Add double excitations.
+            * GD: Add generalized double excitations.
+            * pD: Add pair double excitations.
+            * GpD: Add generalized pair double excitations.
+            * SAD: Add spin-adapted doubles.
+            * SAGD: Add generalized spin-adapted doubles.
+
         Args:
-            cas: CAS(num_active_elec, num_active_orbs),
+            active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
                  orbitals are counted in spatial basis.
             mo_coeffs: Initial orbital coefficients.
             integral_generator: Integral generator object.
             excitations: Unitary coupled cluster excitation operators.
-            include_active_kappa: Include active-active orbital rotations.
+            wavefunction_options: Wavefunction options.
         """
-        if len(cas) != 2:
-            raise ValueError(f"cas must have two elements, got {len(cas)} elements.")
+        if wavefunction_options is None:
+            wavefunction_options = {}
+        self.wavefunction_options = copy.deepcopy(wavefunction_options)
+        valid_options = (
+            "resolve_unpaired_idx",
+            "include_active_kappa",
+            "reference_determiant",
+        )
+        for option in wavefunction_options:
+            if option not in wavefunction_options:
+                raise ValueError(
+                    f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
+                )
+        # Default options
+        self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
+        self.wavefunction_options.setdefault("include_active_kappa", True)
+        if len(active_space) != 2:
+            raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
+        if isinstance(active_space[0], int):
+            if active_space[0] % 2 == 0:
+                cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
+            else:
+                # Uneven number of electrons mean one electron must be unpaired.
+                cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
+        else:
+            cas = ((active_space[0][0], active_space[0][1]), active_space[1])
         # Init stuff
         self.int_gen = IntegralManager(integral_generator)
-        self._c_mo = mo_coeffs
-        self.inactive_spin_idx = []
-        self.virtual_spin_idx = []
-        self.active_spin_idx = []
-        self.active_occ_spin_idx = []
-        self.active_unocc_spin_idx = []
-        self.active_spin_idx_shifted = []
-        self.active_occ_spin_idx_shifted = []
-        self.active_unocc_spin_idx_shifted = []
-        self.active_idx_shifted = []
-        self.active_occ_idx_shifted = []
-        self.active_unocc_idx_shifted = []
-        self.num_spin_orbs = 2 * len(self.int_gen.kinetic_energy)
-        self.num_orbs = len(self.int_gen.kinetic_energy)
-        self._include_active_kappa = include_active_kappa
-        self.num_active_elec = 0
-        self.num_active_spin_orbs = 0
-        self.num_inactive_spin_orbs = 0
-        self.num_virtual_spin_orbs = 0
+        if np.sum(cas[0]) > self.int_gen.num_elec:
+            raise ValueError("More active electrons than total number electrons.")
+        if (np.sum(cas[0]) % 2 == 0 and self.int_gen.num_elec % 2 == 1) or (
+            np.sum(cas[0]) % 2 == 1 and self.int_gen.num_elec % 2 == 0
+        ):
+            raise ValueError("Specified CAS gives odd number of electrons in inactive space.")
+        self.num_inactive_spin_orbs = self.int_gen.num_elec - int(np.sum(cas[0]))
+        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
+        self.num_active_orbs = cas[1]
+        self.num_active_spin_orbs = 2 * self.num_active_orbs
+        self.num_active_orbs = self.num_active_spin_orbs // 2
+        self.num_virtual_orbs = (
+            len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
+        )
+        if self.num_virtual_orbs < 0:
+            raise ValueError(
+                "Number of inactive + number of active orbitals is larger than total number of orbitals."
+            )
+        self.num_virtual_spin_orbs = 2 * self.num_virtual_orbs
+        self.num_orbs = self.num_inactive_orbs + self.num_active_orbs + self.num_virtual_orbs
+        self.num_spin_orbs = 2 * self.num_orbs
+        self.num_active_elec_alpha = cas[0][0]
+        self.num_active_elec_beta = cas[0][1]
+        self.num_active_elec = self.num_active_elec_alpha + self.num_active_elec_beta
         self._rdm1 = None
         self._rdm2 = None
         self._rdm3 = None
@@ -81,81 +134,90 @@ class WaveFunctionUCC:
         self._h_mo = None
         self._g_mo = None
         self._energy_elec: float | None = None
-        # Construct spin orbital spaces and indices
-        active_space = []
-        orbital_counter = 0
-        num_elec = self.int_gen.num_elec
-        for i in range(num_elec - cas[0], num_elec):
-            active_space.append(i)
-            orbital_counter += 1
-        for i in range(num_elec, num_elec + 2 * cas[1] - orbital_counter):
-            active_space.append(i)
-        for i in range(num_elec):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_occ_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-                self.num_active_elec += 1
+        self.num_energy_evals = 0
+        self._c_mo = mo_coeffs
+        # Used when converting to circuit wavefunction.
+        self._include_active_kappa = self.wavefunction_options["include_active_kappa"]
+        # Reference wave function
+        if "reference_determiant" in self.wavefunction_options.keys():
+            ref_det = self.wavefunction_options["reference_determiant"]
+            if len(ref_det) != self.num_active_spin_orbs:
+                raise ValueError(
+                    f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
+                )
+            ref_alpha = 0
+            ref_beta = 0
+            for i, idx in ref_det:
+                if i % 2 == 0 and idx == "1":
+                    ref_alpha += 1
+                elif idx == "1":
+                    ref_beta += 1
+            if ref_alpha != self.num_active_elec_alpha or ref_beta != self.num_active_elec_beta:
+                raise ValueError(
+                    "Number of electrons ({ref_alpha}, {ref_beta}) is different from the active space ({self.num_active_elec_alpha, self.num_active_elec_beta})."
+                )
+        else:
+            ref_det = ""
+            for i in range(self.num_active_orbs):
+                if i < self.num_active_elec_alpha:
+                    ref_det += "1"
+                else:
+                    ref_det += "0"
+                if i < self.num_active_elec_beta:
+                    ref_det += "1"
+                else:
+                    ref_det += "0"
+        # Construct spin orbital indices
+        self.inactive_spin_idx = [x for x in range(self.num_inactive_spin_orbs)]
+        self.active_spin_idx = [x + self.num_inactive_spin_orbs for x in range(self.num_active_spin_orbs)]
+        self.virtual_spin_idx = [
+            x + self.num_inactive_spin_orbs + self.num_active_spin_orbs
+            for x in range(self.num_virtual_spin_orbs)
+        ]
+        self.active_occ_spin_idx = []
+        self.active_unocc_spin_idx = []
+        for i, orb_idx in enumerate(self.active_spin_idx):
+            if ref_det[i] == "1":
+                self.active_occ_spin_idx.append(orb_idx)
             else:
-                self.inactive_spin_idx.append(i)
-                self.num_inactive_spin_orbs += 1
-        for i in range(num_elec, self.num_spin_orbs):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_unocc_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-            else:
-                self.virtual_spin_idx.append(i)
-                self.num_virtual_spin_orbs += 1
-        self.num_active_elec_alpha = self.num_active_elec // 2
-        self.num_active_elec_beta = self.num_active_elec // 2
-        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
-        self.num_active_orbs = self.num_active_spin_orbs // 2
-        self.num_virtual_orbs = self.num_virtual_spin_orbs // 2
+                self.active_unocc_spin_idx.append(orb_idx)
+        self.active_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_spin_idx]
+        self.active_occ_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_occ_spin_idx]
+        self.active_unocc_spin_idx_shifted = [
+            x - self.num_inactive_spin_orbs for x in self.active_unocc_spin_idx
+        ]
         # Construct spatial idx
-        self.inactive_idx: list[int] = []
-        self.virtual_idx: list[int] = []
-        self.active_idx: list[int] = []
-        self.active_occ_idx: list[int] = []
-        self.active_unocc_idx: list[int] = []
-        for idx in self.inactive_spin_idx:
-            if idx // 2 not in self.inactive_idx:
-                self.inactive_idx.append(idx // 2)
-        for idx in self.active_spin_idx:
-            if idx // 2 not in self.active_idx:
-                self.active_idx.append(idx // 2)
-        for idx in self.virtual_spin_idx:
-            if idx // 2 not in self.virtual_idx:
-                self.virtual_idx.append(idx // 2)
-        for idx in self.active_occ_spin_idx:
-            if idx // 2 not in self.active_occ_idx:
-                self.active_occ_idx.append(idx // 2)
-        for idx in self.active_unocc_spin_idx:
-            if idx // 2 not in self.active_unocc_idx:
-                self.active_unocc_idx.append(idx // 2)
-        # Make shifted indices
-        if len(self.active_spin_idx) != 0:
-            active_shift = np.min(self.active_spin_idx)
-            for active_idx in self.active_spin_idx:
-                self.active_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_spin_idx:
-                self.active_occ_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_spin_idx:
-                self.active_unocc_spin_idx_shifted.append(active_idx - active_shift)
-        if len(self.active_idx) != 0:
-            active_shift = np.min(self.active_idx)
-            for active_idx in self.active_idx:
-                self.active_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_idx:
-                self.active_occ_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_idx:
-                self.active_unocc_idx_shifted.append(active_idx - active_shift)
+        self.inactive_idx = [x for x in range(self.num_inactive_orbs)]
+        self.active_idx = [x + self.num_inactive_orbs for x in range(self.num_active_orbs)]
+        self.virtual_idx = [
+            x + self.num_inactive_orbs + self.num_active_orbs for x in range(self.num_virtual_orbs)
+        ]
+        self.active_occ_idx = []
+        self.active_unocc_idx = []
+        for i, orb_idx in enumerate(self.active_idx):
+            if ref_det[2 * i] == "1" and ref_det[2 * i + 1] == "1":
+                self.active_occ_idx.append(orb_idx)
+            elif ref_det[2 * i] == "0" and ref_det[2 * i + 1] == "0":
+                self.active_unocc_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "both":
+                self.active_occ_idx.append(orb_idx)
+                self.active_unocc_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
+                self.active_occ_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
+                self.active_unocc_idx.append(orb_idx)
+            else:
+                raise ValueError(
+                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'."
+                )
+        self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
+        self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
+        self.active_unocc_idx_shifted = [x - self.num_inactive_orbs for x in self.active_unocc_idx]
         # Find non-redundant kappas
         self._kappa = []
         kappa_idx = []
         kappa_no_activeactive_idx = []
         kappa_no_activeactive_idx_dagger = []
-        kappa_redundant_idx = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
         # Loop over all q>p orb combinations and find redundant kappas
@@ -163,14 +225,11 @@ class WaveFunctionUCC:
             for q in range(p + 1, self.num_orbs):
                 # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
-                if not include_active_kappa:
+                if not self._include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
-                        kappa_redundant_idx.append((p, q))
                         continue
                 if not (p in self.active_idx and q in self.active_idx):
                     kappa_no_activeactive_idx.append((p, q))
@@ -192,7 +251,6 @@ class WaveFunctionUCC:
         self.kappa_idx = np.array(kappa_idx, dtype=int)
         self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
         self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
         self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         # Construct determinant basis
         self.ci_info = get_indexing(
@@ -203,31 +261,20 @@ class WaveFunctionUCC:
             self.num_active_elec_beta,
         )
         self.num_det = len(self.ci_info.idx2det)
-        self.csf_coeffs = np.zeros(self.num_det)
-        hf_det = int("1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec), 2)
-        self.csf_coeffs[self.ci_info.det2idx[hf_det]] = 1
-        self._ci_coeffs = np.copy(self.csf_coeffs)
+        self.ref_coeffs = np.zeros(self.num_det, dtype=float)
+        print("Reference (active) determinant:", ref_det)
+        self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
+        self.ci_coeffs = np.copy(self.ref_coeffs)
         # Construct UCC Structure
-        self._excitations = excitations  # Needed for saving the wave function
         self.ucc_layout = UccStructure()
-        if "s" in excitations.lower():
-            self.ucc_layout.add_sa_singles(self.active_occ_idx_shifted, self.active_unocc_idx_shifted)
-        if "d" in excitations.lower():
-            self.ucc_layout.add_sa_doubles(self.active_occ_idx_shifted, self.active_unocc_idx_shifted)
-        if "t" in excitations.lower():
-            self.ucc_layout.add_triples(self.active_occ_spin_idx_shifted, self.active_unocc_spin_idx_shifted)
-        if "q" in excitations.lower():
-            self.ucc_layout.add_quadruples(
-                self.active_occ_spin_idx_shifted, self.active_unocc_spin_idx_shifted
-            )
-        if "5" in excitations.lower():
-            self.ucc_layout.add_quintuples(
-                self.active_occ_spin_idx_shifted, self.active_unocc_spin_idx_shifted
-            )
-        if "6" in excitations.lower():
-            self.ucc_layout.add_sextuples(
-                self.active_occ_spin_idx_shifted, self.active_unocc_spin_idx_shifted
-            )
+        self.ucc_layout.add_excitations(
+            excitations,
+            self.active_occ_idx_shifted,
+            self.active_unocc_idx_shifted,
+            self.active_occ_spin_idx_shifted,
+            self.active_unocc_spin_idx_shifted,
+            self.num_active_orbs,
+        )
         self._thetas = np.zeros(self.ucc_layout.n_params).tolist()
 
     @property
@@ -249,22 +296,6 @@ class WaveFunctionUCC:
         # Move current expansion point.
         self._c_mo = self.c_mo
         self._kappa_old = self.kappa
-
-    @property
-    def ci_coeffs(self) -> np.ndarray:
-        """Get CI coefficients.
-
-        Returns:
-            State vector.
-        """
-        if self._ci_coeffs is None:
-            self._ci_coeffs = construct_ucc_state(
-                self.csf_coeffs,
-                self.ci_info,
-                self.thetas,
-                self.ucc_layout,
-            )
-        return self._ci_coeffs
 
     @property
     def thetas(self) -> list[float]:
@@ -289,7 +320,12 @@ class WaveFunctionUCC:
         self._rdm3 = None
         self._rdm4 = None
         self._energy_elec = None
-        self._ci_coeffs = None
+        self.ci_coeffs = construct_ucc_state(
+            self.ref_coeffs,
+            self.ci_info,
+            self.thetas,
+            self.ucc_layout,
+        )
         self._thetas = theta.copy()
 
     @property
@@ -344,19 +380,19 @@ class WaveFunctionUCC:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs))
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     val = expectation_value(
                         self.ci_coeffs,
                         [Epq(p, q)],
                         self.ci_coeffs,
                         self.ci_info,
                     )
-                    self._rdm1[p_idx, q_idx] = val  # type: ignore
-                    self._rdm1[q_idx, p_idx] = val  # type: ignore
+                    self._rdm1[p_, q_] = val  # type: ignore
+                    self._rdm1[q_, p_] = val  # type: ignore
         return self._rdm1
 
     @property
@@ -373,14 +409,15 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         if p == q:
                             s_lim = r + 1
                         elif p == r:
@@ -390,19 +427,19 @@ class WaveFunctionUCC:
                         else:
                             s_lim = p + 1
                         for s in range(self.num_inactive_orbs, s_lim):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             val = expectation_value(
                                 self.ci_coeffs,
-                                [Epq(p, q), Epq(r, s)],
+                                [Epq(p, q) * Epq(r, s)],
                                 self.ci_coeffs,
                                 self.ci_info,
                             )
                             if q == r:
-                                val -= self.rdm1[p_idx, s_idx]
-                            self._rdm2[p_idx, q_idx, r_idx, s_idx] = val  # type: ignore
-                            self._rdm2[r_idx, s_idx, p_idx, q_idx] = val  # type: ignore
-                            self._rdm2[q_idx, p_idx, s_idx, r_idx] = val  # type: ignore
-                            self._rdm2[s_idx, r_idx, q_idx, p_idx] = val  # type: ignore
+                                val -= self.rdm1[p_, s_]
+                            self._rdm2[p_, q_, r_, s_] = val  # type: ignore
+                            self._rdm2[r_, s_, p_, q_] = val  # type: ignore
+                            self._rdm2[q_, p_, s_, r_] = val  # type: ignore
+                            self._rdm2[s_, r_, q_, p_] = val  # type: ignore
         return self._rdm2
 
     @property
@@ -423,20 +460,21 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         for s in range(self.num_inactive_orbs, p + 1):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             for t in range(self.num_inactive_orbs, r + 1):
-                                t_idx = t - self.num_inactive_orbs
+                                t_ = t - self.num_inactive_orbs
                                 for u in range(self.num_inactive_orbs, p + 1):
-                                    u_idx = u - self.num_inactive_orbs
+                                    u_ = u - self.num_inactive_orbs
                                     val = expectation_value(
                                         self.ci_coeffs,
                                         [Epq(p, q), Epq(r, s), Epq(t, u)],
@@ -444,25 +482,25 @@ class WaveFunctionUCC:
                                         self.ci_info,
                                     )
                                     if t == s:
-                                        val -= self.rdm2[p_idx, q_idx, r_idx, u_idx]
+                                        val -= self.rdm2[p_, q_, r_, u_]
                                     if r == q:
-                                        val -= self.rdm2[p_idx, s_idx, t_idx, u_idx]
+                                        val -= self.rdm2[p_, s_, t_, u_]
                                     if t == q:
-                                        val -= self.rdm2[p_idx, u_idx, r_idx, s_idx]
+                                        val -= self.rdm2[p_, u_, r_, s_]
                                     if t == s and r == q:
-                                        val -= self.rdm1[p_idx, u_idx]
-                                    self._rdm3[p_idx, q_idx, r_idx, s_idx, t_idx, u_idx] = val  # type: ignore
-                                    self._rdm3[p_idx, q_idx, t_idx, u_idx, r_idx, s_idx] = val  # type: ignore
-                                    self._rdm3[r_idx, s_idx, p_idx, q_idx, t_idx, u_idx] = val  # type: ignore
-                                    self._rdm3[r_idx, s_idx, t_idx, u_idx, p_idx, q_idx] = val  # type: ignore
-                                    self._rdm3[t_idx, u_idx, p_idx, q_idx, r_idx, s_idx] = val  # type: ignore
-                                    self._rdm3[t_idx, u_idx, r_idx, s_idx, p_idx, q_idx] = val  # type: ignore
-                                    self._rdm3[q_idx, p_idx, s_idx, r_idx, u_idx, t_idx] = val  # type: ignore
-                                    self._rdm3[q_idx, p_idx, u_idx, t_idx, s_idx, r_idx] = val  # type: ignore
-                                    self._rdm3[s_idx, r_idx, q_idx, p_idx, u_idx, t_idx] = val  # type: ignore
-                                    self._rdm3[s_idx, r_idx, u_idx, t_idx, q_idx, p_idx] = val  # type: ignore
-                                    self._rdm3[u_idx, t_idx, q_idx, p_idx, s_idx, r_idx] = val  # type: ignore
-                                    self._rdm3[u_idx, t_idx, s_idx, r_idx, q_idx, p_idx] = val  # type: ignore
+                                        val -= self.rdm1[p_, u_]
+                                    self._rdm3[p_, q_, r_, s_, t_, u_] = val  # type: ignore
+                                    self._rdm3[p_, q_, t_, u_, r_, s_] = val  # type: ignore
+                                    self._rdm3[r_, s_, p_, q_, t_, u_] = val  # type: ignore
+                                    self._rdm3[r_, s_, t_, u_, p_, q_] = val  # type: ignore
+                                    self._rdm3[t_, u_, p_, q_, r_, s_] = val  # type: ignore
+                                    self._rdm3[t_, u_, r_, s_, p_, q_] = val  # type: ignore
+                                    self._rdm3[q_, p_, s_, r_, u_, t_] = val  # type: ignore
+                                    self._rdm3[q_, p_, u_, t_, s_, r_] = val  # type: ignore
+                                    self._rdm3[s_, r_, q_, p_, u_, t_] = val  # type: ignore
+                                    self._rdm3[s_, r_, u_, t_, q_, p_] = val  # type: ignore
+                                    self._rdm3[u_, t_, q_, p_, s_, r_] = val  # type: ignore
+                                    self._rdm3[u_, t_, s_, r_, q_, p_] = val  # type: ignore
         return self._rdm3
 
     @property
@@ -485,24 +523,25 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         for s in range(self.num_inactive_orbs, p + 1):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             for t in range(self.num_inactive_orbs, r + 1):
-                                t_idx = t - self.num_inactive_orbs
+                                t_ = t - self.num_inactive_orbs
                                 for u in range(self.num_inactive_orbs, p + 1):
-                                    u_idx = u - self.num_inactive_orbs
+                                    u_ = u - self.num_inactive_orbs
                                     for m in range(self.num_inactive_orbs, t + 1):
-                                        m_idx = m - self.num_inactive_orbs
+                                        m_ = m - self.num_inactive_orbs
                                         for n in range(self.num_inactive_orbs, p + 1):
-                                            n_idx = n - self.num_inactive_orbs
+                                            n_ = n - self.num_inactive_orbs
                                             val = expectation_value(
                                                 self.ci_coeffs,
                                                 [Epq(p, q), Epq(r, s), Epq(t, u), Epq(m, n)],
@@ -510,189 +549,90 @@ class WaveFunctionUCC:
                                                 self.ci_info,
                                             )
                                             if r == q:
-                                                val -= self.rdm3[p_idx, s_idx, t_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, s_, t_, u_, m_, n_]
                                             if t == q:
-                                                val -= self.rdm3[p_idx, u_idx, r_idx, s_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, u_, r_, s_, m_, n_]
                                             if m == q:
-                                                val -= self.rdm3[p_idx, n_idx, r_idx, s_idx, t_idx, u_idx]
+                                                val -= self.rdm3[p_, n_, r_, s_, t_, u_]
                                             if m == u:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, s_idx, t_idx, n_idx]
+                                                val -= self.rdm3[p_, q_, r_, s_, t_, n_]
                                             if t == s:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, q_, r_, u_, m_, n_]
                                             if m == s:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, n_idx, t_idx, u_idx]
+                                                val -= self.rdm3[p_, q_, r_, n_, t_, u_]
                                             if m == u and r == q:
-                                                val -= self.rdm2[p_idx, s_idx, t_idx, n_idx]
+                                                val -= self.rdm2[p_, s_, t_, n_]
                                             if m == u and t == q:
-                                                val -= self.rdm2[p_idx, n_idx, r_idx, s_idx]
+                                                val -= self.rdm2[p_, n_, r_, s_]
                                             if t == s and m == u:
-                                                val -= self.rdm2[p_idx, q_idx, r_idx, n_idx]
+                                                val -= self.rdm2[p_, q_, r_, n_]
                                             if t == s and r == q:
-                                                val -= self.rdm2[p_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm2[p_, u_, m_, n_]
                                             if t == s and m == q:
-                                                val -= self.rdm2[p_idx, n_idx, r_idx, u_idx]
+                                                val -= self.rdm2[p_, n_, r_, u_]
                                             if m == s and r == q:
-                                                val -= self.rdm2[p_idx, n_idx, t_idx, u_idx]
+                                                val -= self.rdm2[p_, n_, t_, u_]
                                             if m == s and t == q:
-                                                val -= self.rdm2[p_idx, u_idx, r_idx, n_idx]
+                                                val -= self.rdm2[p_, u_, r_, n_]
                                             if m == u and t == s and r == q:
-                                                val -= self.rdm1[p_idx, n_idx]
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, r_idx, s_idx, t_idx, u_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, r_idx, s_idx, m_idx, n_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, t_idx, u_idx, r_idx, s_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, t_idx, u_idx, m_idx, n_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, m_idx, n_idx, r_idx, s_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, m_idx, n_idx, t_idx, u_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, p_idx, q_idx, t_idx, u_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, p_idx, q_idx, m_idx, n_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, t_idx, u_idx, p_idx, q_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, t_idx, u_idx, m_idx, n_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, m_idx, n_idx, p_idx, q_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, m_idx, n_idx, t_idx, u_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, p_idx, q_idx, r_idx, s_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, p_idx, q_idx, m_idx, n_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, r_idx, s_idx, p_idx, q_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, r_idx, s_idx, m_idx, n_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, m_idx, n_idx, p_idx, q_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, m_idx, n_idx, r_idx, s_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, p_idx, q_idx, r_idx, s_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, p_idx, q_idx, t_idx, u_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, r_idx, s_idx, p_idx, q_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, r_idx, s_idx, t_idx, u_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, t_idx, u_idx, p_idx, q_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, t_idx, u_idx, r_idx, s_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, s_idx, r_idx, u_idx, t_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, s_idx, r_idx, n_idx, m_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, u_idx, t_idx, s_idx, r_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, u_idx, t_idx, n_idx, m_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, n_idx, m_idx, s_idx, r_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, n_idx, m_idx, u_idx, t_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, q_idx, p_idx, u_idx, t_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, q_idx, p_idx, n_idx, m_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, u_idx, t_idx, q_idx, p_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, u_idx, t_idx, n_idx, m_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, n_idx, m_idx, q_idx, p_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, n_idx, m_idx, u_idx, t_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, q_idx, p_idx, s_idx, r_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, q_idx, p_idx, n_idx, m_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, s_idx, r_idx, q_idx, p_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, s_idx, r_idx, n_idx, m_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, n_idx, m_idx, q_idx, p_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, n_idx, m_idx, s_idx, r_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, q_idx, p_idx, s_idx, r_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, q_idx, p_idx, u_idx, t_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, s_idx, r_idx, q_idx, p_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, s_idx, r_idx, u_idx, t_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, u_idx, t_idx, q_idx, p_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, u_idx, t_idx, s_idx, r_idx, q_idx, p_idx
-                                            ] = val
+                                                val -= self.rdm1[p_, n_]
+                                            self._rdm4[p_, q_, r_, s_, t_, u_, m_, n_] = val  # type: ignore
+                                            self._rdm4[p_, q_, r_, s_, m_, n_, t_, u_] = val  # type: ignore
+                                            self._rdm4[p_, q_, t_, u_, r_, s_, m_, n_] = val  # type: ignore
+                                            self._rdm4[p_, q_, t_, u_, m_, n_, r_, s_] = val  # type: ignore
+                                            self._rdm4[p_, q_, m_, n_, r_, s_, t_, u_] = val  # type: ignore
+                                            self._rdm4[p_, q_, m_, n_, t_, u_, r_, s_] = val  # type: ignore
+                                            self._rdm4[r_, s_, p_, q_, t_, u_, m_, n_] = val  # type: ignore
+                                            self._rdm4[r_, s_, p_, q_, m_, n_, t_, u_] = val  # type: ignore
+                                            self._rdm4[r_, s_, t_, u_, p_, q_, m_, n_] = val  # type: ignore
+                                            self._rdm4[r_, s_, t_, u_, m_, n_, p_, q_] = val  # type: ignore
+                                            self._rdm4[r_, s_, m_, n_, p_, q_, t_, u_] = val  # type: ignore
+                                            self._rdm4[r_, s_, m_, n_, t_, u_, p_, q_] = val  # type: ignore
+                                            self._rdm4[t_, u_, p_, q_, r_, s_, m_, n_] = val  # type: ignore
+                                            self._rdm4[t_, u_, p_, q_, m_, n_, r_, s_] = val  # type: ignore
+                                            self._rdm4[t_, u_, r_, s_, p_, q_, m_, n_] = val  # type: ignore
+                                            self._rdm4[t_, u_, r_, s_, m_, n_, p_, q_] = val  # type: ignore
+                                            self._rdm4[t_, u_, m_, n_, p_, q_, r_, s_] = val  # type: ignore
+                                            self._rdm4[t_, u_, m_, n_, r_, s_, p_, q_] = val  # type: ignore
+                                            self._rdm4[m_, n_, p_, q_, r_, s_, t_, u_] = val  # type: ignore
+                                            self._rdm4[m_, n_, p_, q_, t_, u_, r_, s_] = val  # type: ignore
+                                            self._rdm4[m_, n_, r_, s_, p_, q_, t_, u_] = val  # type: ignore
+                                            self._rdm4[m_, n_, r_, s_, t_, u_, p_, q_] = val  # type: ignore
+                                            self._rdm4[m_, n_, t_, u_, p_, q_, r_, s_] = val  # type: ignore
+                                            self._rdm4[m_, n_, t_, u_, r_, s_, p_, q_] = val  # type: ignore
+                                            self._rdm4[q_, p_, s_, r_, u_, t_, n_, m_] = val  # type: ignore
+                                            self._rdm4[q_, p_, s_, r_, n_, m_, u_, t_] = val  # type: ignore
+                                            self._rdm4[q_, p_, u_, t_, s_, r_, n_, m_] = val  # type: ignore
+                                            self._rdm4[q_, p_, u_, t_, n_, m_, s_, r_] = val  # type: ignore
+                                            self._rdm4[q_, p_, n_, m_, s_, r_, u_, t_] = val  # type: ignore
+                                            self._rdm4[q_, p_, n_, m_, u_, t_, s_, r_] = val  # type: ignore
+                                            self._rdm4[s_, r_, q_, p_, u_, t_, n_, m_] = val  # type: ignore
+                                            self._rdm4[s_, r_, q_, p_, n_, m_, u_, t_] = val  # type: ignore
+                                            self._rdm4[s_, r_, u_, t_, q_, p_, n_, m_] = val  # type: ignore
+                                            self._rdm4[s_, r_, u_, t_, n_, m_, q_, p_] = val  # type: ignore
+                                            self._rdm4[s_, r_, n_, m_, q_, p_, u_, t_] = val  # type: ignore
+                                            self._rdm4[s_, r_, n_, m_, u_, t_, q_, p_] = val  # type: ignore
+                                            self._rdm4[u_, t_, q_, p_, s_, r_, n_, m_] = val  # type: ignore
+                                            self._rdm4[u_, t_, q_, p_, n_, m_, s_, r_] = val  # type: ignore
+                                            self._rdm4[u_, t_, s_, r_, q_, p_, n_, m_] = val  # type: ignore
+                                            self._rdm4[u_, t_, s_, r_, n_, m_, q_, p_] = val  # type: ignore
+                                            self._rdm4[u_, t_, n_, m_, q_, p_, s_, r_] = val  # type: ignore
+                                            self._rdm4[u_, t_, n_, m_, s_, r_, q_, p_] = val  # type: ignore
+                                            self._rdm4[n_, m_, q_, p_, s_, r_, u_, t_] = val  # type: ignore
+                                            self._rdm4[n_, m_, q_, p_, u_, t_, s_, r_] = val  # type: ignore
+                                            self._rdm4[n_, m_, s_, r_, q_, p_, u_, t_] = val  # type: ignore
+                                            self._rdm4[n_, m_, s_, r_, u_, t_, q_, p_] = val  # type: ignore
+                                            self._rdm4[n_, m_, u_, t_, q_, p_, s_, r_] = val  # type: ignore
+                                            self._rdm4[n_, m_, u_, t_, s_, r_, q_, p_] = val  # type: ignore
         return self._rdm4
 
-    def check_orthonormality(self, overlap_integral: np.ndarray) -> None:
+    def check_orthonormality(self) -> None:
         r"""Check orthonormality of orbitals.
 
         .. math::
             \boldsymbol{I} = \boldsymbol{C}_\text{MO}\boldsymbol{S}\boldsymbol{C}_\text{MO}^T
-
-        Args:
-            overlap_integral: Overlap integral in AO basis.
         """
-        S_ortho = one_electron_integral_transform(self.c_mo, overlap_integral)
+        S_ortho = one_electron_integral_transform(self.c_mo, self.int_gen.overlap)
         one = np.identity(len(S_ortho))
         diff = np.abs(S_ortho - one)
         print("Max ortho-normal diff:", np.max(diff))
@@ -748,9 +688,16 @@ class WaveFunctionUCC:
         num_theta5 = 0
         num_theta6 = 0
         for exc_type in self.ucc_layout.excitation_operator_type:
-            if exc_type == "sa_single":
+            if exc_type == ("sa_single", "single"):
                 num_theta1 += 1
-            elif exc_type in ("sa_double_1", "sa_double_2", "sa_double_3", "sa_double_4", "sa_double_5"):
+            elif exc_type in (
+                "sa_double_1",
+                "sa_double_2",
+                "sa_double_3",
+                "sa_double_4",
+                "sa_double_5",
+                "double",
+            ):
                 num_theta2 += 1
             elif exc_type == "triple":
                 num_theta3 += 1
@@ -880,9 +827,16 @@ class WaveFunctionUCC:
         num_theta5 = 0
         num_theta6 = 0
         for exc_type in self.ucc_layout.excitation_operator_type:
-            if exc_type == "sa_single":
+            if exc_type == ("sa_single", "single"):
                 num_theta1 += 1
-            elif exc_type in ("sa_double_1", "sa_double_2", "sa_double_3", "sa_double_4", "sa_double_5"):
+            elif exc_type in (
+                "sa_double_1",
+                "sa_double_2",
+                "sa_double_3",
+                "sa_double_4",
+                "sa_double_5",
+                "double",
+            ):
                 num_theta2 += 1
             elif exc_type == "triple":
                 num_theta3 += 1
@@ -1091,7 +1045,7 @@ class WaveFunctionUCC:
                     get_ucc_T(theta_params, self.ucc_layout),
                     self.ci_info,
                 )
-                bra = ss.linalg.expm_multiply(Tmat + Tmat_plus, self.csf_coeffs, traceA=0.0)
+                bra = ss.linalg.expm_multiply(Tmat + Tmat_plus, self.ref_coeffs, traceA=0.0)
                 E_plus = bra @ Hket
                 theta_params[i] -= step_size
                 gradient[i + num_kappa] = 2 * (E_plus - E) / step_size

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -52,7 +52,7 @@ class WaveFunctionUCC:
                                           'occ', include spatial index only in occ idx list.
                                           'unocc', include spatial index only in unocc idx list.
                                           (default: 'both')
-            * reference_determiant [str]: Specify a reference determinant for the active space part.
+            * reference_determinant [str]: Specify a reference determinant for the active space part.
                                           1 specifying occupied orbital and 0 specifying unoccupied orbital.
 
         Possible excitations:
@@ -81,7 +81,7 @@ class WaveFunctionUCC:
         valid_options = (
             "resolve_unpaired_idx",
             "include_active_kappa",
-            "reference_determiant",
+            "reference_determinant",
         )
         for option in wavefunction_options:
             if option not in valid_options:
@@ -134,13 +134,12 @@ class WaveFunctionUCC:
         self._h_mo = None
         self._g_mo = None
         self._energy_elec: float | None = None
-        self.num_energy_evals = 0
         self._c_mo = mo_coeffs
         # Used when converting to circuit wavefunction.
         self._include_active_kappa = self.wavefunction_options["include_active_kappa"]
         # Reference wave function
-        if "reference_determiant" in self.wavefunction_options.keys():
-            ref_det = self.wavefunction_options["reference_determiant"]
+        if "reference_determinant" in self.wavefunction_options.keys():
+            ref_det = self.wavefunction_options["reference_determinant"]
             if len(ref_det) != self.num_active_spin_orbs:
                 raise ValueError(
                     f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
@@ -208,7 +207,7 @@ class WaveFunctionUCC:
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, expected 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -248,10 +247,10 @@ class WaveFunctionUCC:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=int)
-        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
-        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
+        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
+        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=np.int64)
+        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=np.int64)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
         # Construct determinant basis
         self.ci_info = get_indexing(
             self.num_inactive_orbs,
@@ -261,7 +260,7 @@ class WaveFunctionUCC:
             self.num_active_elec_beta,
         )
         self.num_det = len(self.ci_info.idx2det)
-        self.ref_coeffs = np.zeros(self.num_det, dtype=float)
+        self.ref_coeffs = np.zeros(self.num_det, dtype=np.float64)
         print("Reference (active) determinant:", ref_det)
         self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
         self.ci_coeffs = np.copy(self.ref_coeffs)
@@ -380,7 +379,7 @@ class WaveFunctionUCC:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=np.float64)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -410,7 +409,7 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=float,
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -461,7 +460,7 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=float,
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -524,7 +523,7 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=float,
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -660,75 +659,140 @@ class WaveFunctionUCC:
             )
         return self._energy_elec
 
-    def run_wf_optimization_2step(
+    def run_wf_optimization(
         self,
-        optimizer_name: str,
         orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
-        is_silent_subiterations: bool = False,
+        optimization_options: dict[str, Any] | None = None,
     ) -> None:
-        """Run two step optimization of wave function.
+        """Run variational optimization of wavefunction.
+
+        Optimization options:
+            * theta_optimization [bool]: Perform theta optimization.
+                                         (default: True)
+            * theta_optimizer [str]: Optimizer used for theta optimization.
+                                     (default: BFGS)
+            * orbital_optimizer [str]: Optimizer used for orbital optimization.
+                                     (default: BFGS)
+            * 1step_optimizer [str]: Optimizer used for 1step optimizer.
+                                     (fallback: copy theta_optimizer)
+            * opt_type [str]: Optimization type, can be '1step' or '2step'.
+                              (default: 1step)
+            * is_silent_subiterations [bool]: Silence sub iterations in 2step.
+                                              (default: False)
 
         Args:
-            optimizer_name: Name of optimizer.
             orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
+            tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            is_silent_subiterations: Silence subiterations.
+            optimization_options: Additional optimization options.
         """
-        # Init parameters
-        num_kappa = 0
-        if orbital_optimization:
-            num_kappa = len(self.kappa)
-        num_theta1 = 0
-        num_theta2 = 0
-        num_theta3 = 0
-        num_theta4 = 0
-        num_theta5 = 0
-        num_theta6 = 0
-        for exc_type in self.ucc_layout.excitation_operator_type:
-            if exc_type == ("sa_single", "single"):
-                num_theta1 += 1
-            elif exc_type in (
-                "sa_double_1",
-                "sa_double_2",
-                "sa_double_3",
-                "sa_double_4",
-                "sa_double_5",
-                "double",
-            ):
-                num_theta2 += 1
-            elif exc_type == "triple":
-                num_theta3 += 1
-            elif exc_type == "quadruple":
-                num_theta4 += 1
-            elif exc_type == "quintuple":
-                num_theta5 += 1
-            elif exc_type == "sextuple":
-                num_theta6 += 1
-            else:
-                raise ValueError(f"Got unknown excitation type, {exc_type}")
-        # Optimization
-        print("### Parameters information:")
-        print(f"### Number kappa: {num_kappa}")
-        print(f"### Number theta1: {num_theta1}")
-        print(f"### Number theta2: {num_theta2}")
-        print(f"### Number theta3: {num_theta3}")
-        print(f"### Number theta4: {num_theta4}")
-        print(f"### Number theta5: {num_theta5}")
-        print(f"### Number theta6: {num_theta6}")
-        print(
-            f"### Total parameters: {num_kappa + num_theta1 + num_theta2 + num_theta3 + num_theta4 + num_theta5 + num_theta6}\n"
+        if optimization_options is None:
+            optimization_options = {}
+        self._optimization_options = copy.deepcopy(optimization_options)
+        valid_options = (
+            "theta_optimization",
+            "theta_optimizer",
+            "orbital_optimizer",
+            "opt_type",
+            "is_silent_subiterations",
+            "1step_optimizer",
         )
+        for option in self._optimization_options:
+            if option not in valid_options:
+                raise ValueError(
+                    f"Got unknown option for optimization, {option}. Valid options are: {valid_options}"
+                )
+        self._optimization_options["tol"] = tol
+        self._optimization_options["maxiter"] = int(maxiter)
+        self._optimization_options["orbital_optimization"] = orbital_optimization
+        self._optimization_options.setdefault("theta_optimization", True)
+        self._optimization_options.setdefault("theta_optimizer", "BFGS")
+        self._optimization_options.setdefault("orbital_optimizer", "BFGS")
+        self._optimization_options.setdefault("opt_type", "1step")
+        self._optimization_options.setdefault("is_silent_subiterations", False)
+        if len(self.kappa) == 0 and self._optimization_options["orbital_optimization"]:
+            print("No kappa parameters turning off orbital optimization.")
+        if len(self.thetas) == 0 and self._optimization_options["theta_optimization"]:
+            print("No thetas parameters turning off theta optimization.")
+        if self._optimization_options["opt_type"].lower() == "2step" and (
+            not self._optimization_options["orbital_optimization"]
+            or not self._optimization_options["theta_optimization"]
+        ):
+            if not self._optimization_options["orbital_optimization"]:
+                print("Orbital optimization not requested changing optimizer type to 1step.")
+                self._optimization_options["opt_type"] = "1step"
+            elif not self._optimization_options["theta_optimization"]:
+                print("theta optimization not requested changing optimizer type to 1step.")
+                self._optimization_options["opt_type"] = "1step"
+        if (
+            self._optimization_options["opt_type"].lower() == "1step"
+            and "1step_optimizer" not in self._optimization_options.keys()
+        ):
+            print(
+                "'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
+            )
+            self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
+        print("### Parameters information:")
+        if self._optimization_options["orbital_optimization"]:
+            print(f"### Number kappa: {len(self.kappa)}")
+        if self._optimization_options["theta_optimization"]:
+            num_theta1 = 0
+            num_theta2 = 0
+            num_theta3 = 0
+            num_theta4 = 0
+            num_theta5 = 0
+            num_theta6 = 0
+            for exc_type in self.ucc_layout.excitation_operator_type:
+                if exc_type == ("sa_single", "single"):
+                    num_theta1 += 1
+                elif exc_type in (
+                    "sa_double_1",
+                    "sa_double_2",
+                    "sa_double_3",
+                    "sa_double_4",
+                    "sa_double_5",
+                    "double",
+                ):
+                    num_theta2 += 1
+                elif exc_type == "triple":
+                    num_theta3 += 1
+                elif exc_type == "quadruple":
+                    num_theta4 += 1
+                elif exc_type == "quintuple":
+                    num_theta5 += 1
+                elif exc_type == "sextuple":
+                    num_theta6 += 1
+                else:
+                    raise ValueError(f"Got unknown excitation type, {exc_type}")
+                print("### Parameters information:")
+                print(f"### Number theta1: {num_theta1}")
+                print(f"### Number theta2: {num_theta2}")
+                print(f"### Number theta3: {num_theta3}")
+                print(f"### Number theta4: {num_theta4}")
+                print(f"### Number theta5: {num_theta5}")
+                print(f"### Number theta6: {num_theta6}")
+        if self._optimization_options["opt_type"].lower() == "1step":
+            self._run_wf_optimization_1step()
+        elif self._optimization_options["opt_type"].lower() == "2step":
+            self._run_wf_optimization_1step()
+        else:
+            raise ValueError(
+                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."
+            )
+
+    def _run_wf_optimization_2step(
+        self,
+    ) -> None:
+        """Run two step optimization of wave function."""
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree]")
-        for full_iter in range(0, int(maxiter)):
+        for full_iter in range(0, self._optimization_options["maxiter"]):
             full_start = time.time()
-
             # Do ansatz optimization
-            if not is_silent_subiterations:
+            if not self._optimization_options["is_silent_subiterations"]:
                 print("--------UCC optimization")
                 print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree]")
             energy_theta = partial(
@@ -743,126 +807,61 @@ class WaveFunctionUCC:
             )
             optimizer = Optimizers(
                 energy_theta,
-                optimizer_name,
+                self._optimization_options["theta_optimizer"],
                 grad=gradient_theta,
-                maxiter=maxiter,
-                tol=tol,
-                is_silent=is_silent_subiterations,
+                maxiter=self._optimization_options["maxiter"],
+                tol=self._optimization_options["tol"],
+                is_silent=self._optimization_options["is_silent_subiterations"],
             )
             self._old_opt_parameters = np.zeros_like(self.thetas) + 10**20
             self._E_opt_old = 0.0
             res = optimizer.minimize(self.thetas)
             self.thetas = res.x.tolist()
 
-            if orbital_optimization and len(self.kappa) != 0:
-                if not is_silent_subiterations:
-                    print("--------Orbital optimization")
-                    print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree]")
-                energy_oo = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-                gradient_oo = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
+            if not self._optimization_options["is_silent_subiterations"]:
+                print("--------Orbital optimization")
+                print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree]")
+            energy_oo = partial(
+                self._calc_energy_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
+            gradient_oo = partial(
+                self._calc_gradient_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
 
-                optimizer = Optimizers(
-                    energy_oo,
-                    "l-bfgs-b",
-                    grad=gradient_oo,
-                    maxiter=maxiter,
-                    tol=tol,
-                    is_silent=is_silent_subiterations,
-                )
-                self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
-                self._E_opt_old = 0.0
-                res = optimizer.minimize([0.0] * len(self.kappa_idx))
-                for i in range(len(self.kappa)):
-                    self.kappa[i] = 0.0
-                    self._kappa_old[i] = 0.0
-            else:
-                # If theres is no orbital optimization, then the algorithm is already converged.
-                e_new = res.fun
-                if orbital_optimization and len(self.kappa) == 0:
-                    print(
-                        "WARNING: No orbital optimization performed, because there is no non-redundant orbital parameters"
-                    )
-                break
-
+            optimizer = Optimizers(
+                energy_oo,
+                self._optimization_options["orbital_optimizer"],
+                grad=gradient_oo,
+                maxiter=self._optimization_options["maxiter"],
+                tol=self._optimization_options["tol"],
+                is_silent=self._optimization_options["is_silent_subiterations"],
+            )
+            self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
+            self._E_opt_old = 0.0
+            res = optimizer.minimize([0.0] * len(self.kappa_idx))
+            for i in range(len(self.kappa)):
+                self._kappa[i] = 0.0
+                self._kappa_old[i] = 0.0
             e_new = res.fun
             time_str = f"{time.time() - full_start:7.2f}"
             e_str = f"{e_new:3.12f}"
             print(f"{str(full_iter + 1).center(11)} | {time_str.center(18)} | {e_str.center(27)}")
-            if abs(e_new - e_old) < tol:
+            if abs(e_new - e_old) < self._optimization_options["tol"]:
                 break
             e_old = e_new
         self._energy_elec = e_new
 
-    def run_wf_optimization_1step(
+    def _run_wf_optimization_1step(
         self,
-        optimizer_name: str,
-        orbital_optimization: bool = False,
-        tol: float = 1e-10,
-        maxiter: int = 1000,
     ) -> None:
-        """Run one step optimization of wave function.
-
-        Args:
-            optimizer_name: Name of optimizer.
-            orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
-            maxiter: Maximum number of iterations.
-        """
-        # Init parameters
-        num_kappa = 0
-        if orbital_optimization:
-            num_kappa = len(self.kappa)
-        num_theta1 = 0
-        num_theta2 = 0
-        num_theta3 = 0
-        num_theta4 = 0
-        num_theta5 = 0
-        num_theta6 = 0
-        for exc_type in self.ucc_layout.excitation_operator_type:
-            if exc_type == ("sa_single", "single"):
-                num_theta1 += 1
-            elif exc_type in (
-                "sa_double_1",
-                "sa_double_2",
-                "sa_double_3",
-                "sa_double_4",
-                "sa_double_5",
-                "double",
-            ):
-                num_theta2 += 1
-            elif exc_type == "triple":
-                num_theta3 += 1
-            elif exc_type == "quadruple":
-                num_theta4 += 1
-            elif exc_type == "quintuple":
-                num_theta5 += 1
-            elif exc_type == "sextuple":
-                num_theta6 += 1
-            else:
-                raise ValueError(f"Got unknown excitation type, {exc_type}")
-        # Optimization
-        print("### Parameters information:")
-        print(f"### Number kappa: {num_kappa}")
-        print(f"### Number theta1: {num_theta1}")
-        print(f"### Number theta2: {num_theta2}")
-        print(f"### Number theta3: {num_theta3}")
-        print(f"### Number theta4: {num_theta4}")
-        print(f"### Number theta5: {num_theta5}")
-        print(f"### Number theta6: {num_theta6}")
-        print(
-            f"### Total parameters: {num_kappa + num_theta1 + num_theta2 + num_theta3 + num_theta4 + num_theta5 + num_theta6}\n"
-        )
+        """Run one step optimization of wave function."""
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree]")
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
                 energy = partial(
                     self._calc_energy_optimization,
                     theta_optimization=True,
@@ -895,21 +894,26 @@ class WaveFunctionUCC:
                 theta_optimization=True,
                 kappa_optimization=False,
             )
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
         else:
             parameters = self.thetas
-        optimizer = Optimizers(energy, optimizer_name, grad=gradient, maxiter=maxiter, tol=tol)
+        optimizer = Optimizers(
+            energy,
+            self._optimization_options["1step_optimizer"],
+            grad=gradient,
+            maxiter=self._optimization_options["maxiter"],
+            tol=self._optimization_options["tol"],
+        )
         self._old_opt_parameters = np.zeros_like(parameters) + 10**20
         self._E_opt_old = 0.0
-        res = optimizer.minimize(
-            parameters,
-        )
-        if orbital_optimization:
-            self.thetas = res.x[len(self.kappa) :].tolist()
+        res = optimizer.minimize(parameters)
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
+                self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0
                 self._kappa_old[i] = 0.0

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -135,8 +135,6 @@ class WaveFunctionUCC:
         self._g_mo = None
         self._energy_elec: float | None = None
         self._c_mo = mo_coeffs
-        # Used when converting to circuit wavefunction.
-        self._include_active_kappa = self.wavefunction_options["include_active_kappa"]
         # Reference wave function
         if "reference_determinant" in self.wavefunction_options.keys():
             ref_det = self.wavefunction_options["reference_determinant"]
@@ -226,7 +224,7 @@ class WaveFunctionUCC:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
                     continue
-                if not self._include_active_kappa:
+                if not self.wavefunction_options["include_active_kappa"]:
                     if p in self.active_idx and q in self.active_idx:
                         continue
                 if not (p in self.active_idx and q in self.active_idx):
@@ -246,10 +244,10 @@ class WaveFunctionUCC:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
-        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=np.int64)
-        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=np.int64)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
+        self.kappa_idx = np.array(kappa_idx, dtype=int)
+        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
+        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         # Construct determinant basis
         self.ci_info = get_indexing(
             self.num_inactive_orbs,
@@ -259,7 +257,7 @@ class WaveFunctionUCC:
             self.num_active_elec_beta,
         )
         self.num_det = len(self.ci_info.idx2det)
-        self.ref_coeffs = np.zeros(self.num_det, dtype=np.float64)
+        self.ref_coeffs = np.zeros(self.num_det, dtype=float)
         print("Reference (active) determinant:", ref_det)
         self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
         self.ci_coeffs = np.copy(self.ref_coeffs)
@@ -274,6 +272,8 @@ class WaveFunctionUCC:
             self.num_active_orbs,
         )
         self._thetas = np.zeros(self.ucc_layout.n_params).tolist()
+        # Needed
+        self._ref_det = ref_det
 
     @property
     def kappa(self) -> list[float]:
@@ -318,13 +318,13 @@ class WaveFunctionUCC:
         self._rdm3 = None
         self._rdm4 = None
         self._energy_elec = None
+        self._thetas = theta.copy()
         self.ci_coeffs = construct_ucc_state(
             self.ref_coeffs,
             self.ci_info,
             self.thetas,
             self.ucc_layout,
         )
-        self._thetas = theta.copy()
 
     @property
     def c_mo(self) -> np.ndarray:
@@ -354,9 +354,7 @@ class WaveFunctionUCC:
             One-electron Hamiltonian integrals in MO basis.
         """
         if self._h_mo is None:
-            self._h_mo = one_electron_integral_transform(
-                self.c_mo, self.int_gen.kinetic_energy + self.int_gen.nuclear_electron_attraction
-            )
+            self._h_mo = one_electron_integral_transform(self.c_mo, self.int_gen.h_ao)
         return self._h_mo
 
     @property
@@ -378,7 +376,7 @@ class WaveFunctionUCC:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=np.float64)
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -408,7 +406,7 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -459,7 +457,7 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -522,7 +520,7 @@ class WaveFunctionUCC:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -730,7 +728,7 @@ class WaveFunctionUCC:
             and "1step_optimizer" not in self._optimization_options.keys()
         ):
             print(
-                "'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
+                f"'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
             )
             self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
         print("### Parameters information:")
@@ -744,7 +742,7 @@ class WaveFunctionUCC:
             num_theta5 = 0
             num_theta6 = 0
             for exc_type in self.ucc_layout.excitation_operator_type:
-                if exc_type == ("sa_single", "single"):
+                if exc_type in ("sa_single", "single"):
                     num_theta1 += 1
                 elif exc_type in (
                     "sa_double_1",
@@ -775,7 +773,7 @@ class WaveFunctionUCC:
         if self._optimization_options["opt_type"].lower() == "1step":
             self._run_wf_optimization_1step()
         elif self._optimization_options["opt_type"].lower() == "2step":
-            self._run_wf_optimization_1step()
+            self._run_wf_optimization_2step()
         else:
             raise ValueError(
                 f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."

--- a/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ucc_wavefunction.py
@@ -42,7 +42,7 @@ class WaveFunctionUCC:
         include_active_kappa: bool = True,
         resolve_unpaired_idx: str = "both",
     ) -> None:
-        """Initialize for UCC wave function.
+        """Initialize UCC wave function.
 
         Possible excitations:
             * S: Add single excitations.
@@ -183,7 +183,7 @@ class WaveFunctionUCC:
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, expected 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -195,7 +195,7 @@ class WaveFunctionUCC:
         kappa_no_activeactive_idx_dagger = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
-        # Loop over all q>p orb combinations
+        # Loop over all q>p orb combinations.
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
                 if p in self.inactive_idx and q in self.inactive_idx:
@@ -269,6 +269,8 @@ class WaveFunctionUCC:
         self._g_mo = None
         self._energy_elec = None
         self._kappa = k.copy()
+        if isinstance(self._kappa, np.ndarray):
+            self._kappa = self._kappa.tolist()
         # Move current expansion point.
         self._c_mo = self.c_mo
         self._kappa_old = self.kappa
@@ -299,21 +301,23 @@ class WaveFunctionUCC:
         return self._thetas.copy()
 
     @thetas.setter
-    def thetas(self, theta: list[float]) -> None:
-        """Set theta1 values.
+    def thetas(self, theta_vals: list[float]) -> None:
+        """Set theta values.
 
         Args:
-            theta: theta1 values.
+            theta_vals: theta values.
         """
-        if len(theta) != len(self._thetas):
-            raise ValueError(f"Expected {len(self._thetas)} theta1 values got {len(theta)}")
+        if len(theta_vals) != len(self._thetas):
+            raise ValueError(f"Expected {len(self._thetas)} theta1 values got {len(theta_vals)}")
         self._rdm1 = None
         self._rdm2 = None
         self._rdm3 = None
         self._rdm4 = None
         self._energy_elec = None
         self._ci_coeffs = None
-        self._thetas = theta.copy()
+        self._thetas = theta_vals.copy()
+        if isinstance(self._thetas, np.ndarray):
+            self._thetas = self._thetas.tolist()
 
     @property
     def c_mo(self) -> np.ndarray:
@@ -624,7 +628,7 @@ class WaveFunctionUCC:
 
     @property
     def energy_elec(self) -> float:
-        """Get the electronic energy.
+        """Get electronic energy.
 
         Returns:
             Electronic energy.
@@ -731,7 +735,7 @@ class WaveFunctionUCC:
                 tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
             )
         else:
-            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} expected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
@@ -867,10 +871,7 @@ class WaveFunctionUCC:
         self._energy_elec = res.fun
 
     def _calc_energy_optimization(
-        self,
-        parameters: list[float],
-        theta_optimization: bool,
-        kappa_optimization: bool,
+        self, parameters: list[float], theta_optimization: bool, kappa_optimization: bool
     ) -> float:
         r"""Calculate electronic energy of UCC wave function.
 
@@ -878,10 +879,9 @@ class WaveFunctionUCC:
             E = \left<0\left|\hat{H}\right|0\right>
 
         Args:
-            parameters: Sequence of all parameters.
-                        Ordered as orbital rotations, active-space singles, active-space doubles, ...
-            theta_optimization: If used in theta optimization.
-            kappa_optimization: If used in kappa optimization.
+            parameters: Orbital rotations and cluster amplitude parameters.
+            theta_optimization: Doing theta optimization.
+            kappa_optimization: Doing kappa optimization.
 
         Returns:
             Electronic energy.
@@ -939,8 +939,8 @@ class WaveFunctionUCC:
 
         Args:
             parameters: Ansatz and orbital rotation parameters.
-            theta_optimization: If used in theta optimization.
-            kappa_optimization: If used in kappa optimization.
+            theta_optimization: Doing theta optimization.
+            kappa_optimization: Doing kappa optimization.
 
         Returns:
             Electronic gradient.

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -58,7 +58,7 @@ class WaveFunctionUPS:
                                           'occ', include spatial index only in occ idx list.
                                           'unocc', include spatial index only in unocc idx list.
                                           (default: 'both')
-            * reference_determiant [str]: Specify a reference determinant for the active space part.
+            * reference_determinant [str]: Specify a reference determinant for the active space part.
                                           1 specifying occupied orbital and 0 specifying unoccupied orbital.
 
         Args:
@@ -80,7 +80,7 @@ class WaveFunctionUPS:
             "do_pp",
             "resolve_unpaired_idx",
             "include_active_kappa",
-            "reference_determiant",
+            "reference_determinant",
         )
         for option in wavefunction_options:
             if option not in valid_options:
@@ -139,9 +139,9 @@ class WaveFunctionUPS:
         # Reference wave function
         self._pp = self.wavefunction_options["do_pp"]
         if self.wavefunction_options["do_pp"]:
-            if "reference_determiant" in self.wavefunction_options.keys():
+            if "reference_determinant" in self.wavefunction_options.keys():
                 raise ValueError(
-                    "Both 'do_pp' and 'reference_determiant' are requested in 'wavefunction_options'."
+                    "Both 'do_pp' and 'reference_determinant' are requested in 'wavefunction_options'."
                 )
             if self.num_active_elec_alpha != self.num_active_elec_beta:
                 raise ValueError(
@@ -183,8 +183,8 @@ class WaveFunctionUPS:
 
             # Assign weight to reference
             ref_det = pp_det
-        elif "reference_determiant" in self.wavefunction_options.keys():
-            ref_det = self.wavefunction_options["reference_determiant"]
+        elif "reference_determinant" in self.wavefunction_options.keys():
+            ref_det = self.wavefunction_options["reference_determinant"]
             if len(ref_det) != self.num_active_spin_orbs:
                 raise ValueError(
                     f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
@@ -292,10 +292,10 @@ class WaveFunctionUPS:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=int)
-        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
-        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
+        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
+        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=np.int64)
+        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=np.int64)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
         # Construct determinant basis
         self.ci_info = get_indexing(
             self.num_inactive_orbs,
@@ -305,7 +305,7 @@ class WaveFunctionUPS:
             self.num_active_elec_beta,
         )
         self.num_det = len(self.ci_info.idx2det)
-        self.ref_coeffs = np.zeros(self.num_det, dtype=float)
+        self.ref_coeffs = np.zeros(self.num_det, dtype=np.float64)
         print("Reference (active) determinant:", ref_det)
         self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
         self.ci_coeffs = np.copy(self.ref_coeffs)
@@ -463,7 +463,7 @@ class WaveFunctionUPS:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=np.float64)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -493,7 +493,7 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=float,
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -544,7 +544,7 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=float,
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -607,7 +607,7 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=float,
+                dtype=np.float64,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -823,6 +823,7 @@ class WaveFunctionUPS:
             print(
                 "'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
             )
+            self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
         print("### Parameters information:")
         if self._optimization_options["orbital_optimization"]:
             print(f"### Number kappa: {len(self.kappa)}")
@@ -834,7 +835,7 @@ class WaveFunctionUPS:
             self._run_wf_optimization_1step()
         else:
             raise ValueError(
-                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."
+                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excpected '1step' or '2step'."
             )
 
     def _run_wf_optimization_2step(

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -48,7 +48,7 @@ class WaveFunctionUPS:
         resolve_unpaired_idx: str = "both",
         do_pp: bool = False,
     ) -> None:
-        """Initialize for UPS wave function.
+        """Initialize UPS wave function.
 
         Args:
             active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
@@ -116,7 +116,7 @@ class WaveFunctionUPS:
         # Reference wave function
         if do_pp:
             if reference_determinant is not None:
-                raise ValueError("Both 'do_pp' and 'reference_determinant'.")
+                raise ValueError("Both 'do_pp' and 'reference_determinant' are requested.")
             if self.num_active_elec_alpha != self.num_active_elec_beta:
                 raise ValueError(
                     "perfect-pairing is only defined for equal number of alpha and beta electrons."
@@ -225,7 +225,7 @@ class WaveFunctionUPS:
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, expected 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -352,6 +352,8 @@ class WaveFunctionUPS:
         self._g_mo = None
         self._energy_elec = None
         self._kappa = k.copy()
+        if isinstance(self._kappa, np.ndarray):
+            self._kappa = self._kappa.tolist()
         # Move current expansion point.
         self._c_mo = self.c_mo
         self._kappa_old = self.kappa
@@ -397,6 +399,8 @@ class WaveFunctionUPS:
         self._energy_elec = None
         self._ci_coeffs = None
         self._thetas = theta_vals.copy()
+        if isinstance(self._thetas, np.ndarray):
+            self._thetas = self._thetas.tolist()
 
     @property
     def c_mo(self) -> np.ndarray:
@@ -707,7 +711,7 @@ class WaveFunctionUPS:
 
     @property
     def energy_elec(self) -> float:
-        """Get the electronic energy.
+        """Get electronic energy.
 
         Returns:
             Electronic energy.
@@ -786,7 +790,7 @@ class WaveFunctionUPS:
                 tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
             )
         else:
-            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} expected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
@@ -964,9 +968,9 @@ class WaveFunctionUPS:
         """Calculate electronic energy.
 
         Args:
-            parameters: Ansatz and orbital rotation parameters.
-            theta_optimization: If used in theta optimization.
-            kappa_optimization: If used in kappa optimization.
+            parameters: Orbital rotation and ansatz parameters.
+            theta_optimization: Doing theta optimization.
+            kappa_optimization: Doing kappa optimization.
 
         Returns:
             Electronic energy.
@@ -1006,8 +1010,8 @@ class WaveFunctionUPS:
 
         Args:
             parameters: Ansatz and orbital rotation parameters.
-            theta_optimization: If used in theta optimization.
-            kappa_optimization: If used in kappa optimization.
+            theta_optimization: Doing theta optimization.
+            kappa_optimization: Doing kappa optimization.
 
         Returns:
             Electronic gradient.

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -43,23 +43,12 @@ class WaveFunctionUPS:
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         ansatz: str,
         ansatz_options: dict[str, Any] | None = None,
-        wavefunction_options: dict[str, Any] | None = None,
+        reference_determinant: str | None = None,
+        include_active_kappa: bool = True,
+        resolve_unpaired_idx: str = "both",
+        do_pp: bool = False,
     ) -> None:
         """Initialize for UPS wave function.
-
-        Wavefunction Options:
-            * do_pp [bool]: Make perfect-pairing reference determinant.
-                            Will also reorder the orbitalers to match the determinant.
-                            (default: False)
-            * include_active_kappa [bool]: Include active-active orbital rotations.
-                                           (default: True)
-            * resolve_unpaired_idx [str]: Specify how to resolve spatial index with respect to occupation of reference determinant.
-                                          'both', include spatial index in both occ and unocc idx list.
-                                          'occ', include spatial index only in occ idx list.
-                                          'unocc', include spatial index only in unocc idx list.
-                                          (default: 'both')
-            * reference_determinant [str]: Specify a reference determinant for the active space part.
-                                          1 specifying occupied orbital and 0 specifying unoccupied orbital.
 
         Args:
             active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
@@ -68,29 +57,18 @@ class WaveFunctionUPS:
             integral_generator: Integral generator object.
             ansatz: Name of ansatz.
             ansatz_options: Ansatz options.
-            wavefunction_options: Wavefunction options.
+            reference_determinant: Specify a reference determinant for the active space part.
+                                   1 specifying occupied orbital and 0 specifying unoccupied orbital.
+            include_active_kappa: Include active-active orbital rotations.
+            resolve_unpaired_idx: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                  'both', include spatial index in both occ and unocc idx list.
+                                  'occ', include spatial index only in occ idx list.
+                                  'unocc', include spatial index only in unocc idx list.
+            do_pp: Make perfect-pairing reference determinant. Will also reorder the orbitalers to match the determinant.
         """
         if ansatz_options is None:
             ansatz_options = {}
         self.ansatz_options = copy.deepcopy(ansatz_options)
-        if wavefunction_options is None:
-            wavefunction_options = {}
-        self.wavefunction_options = copy.deepcopy(wavefunction_options)
-        valid_options = (
-            "do_pp",
-            "resolve_unpaired_idx",
-            "include_active_kappa",
-            "reference_determinant",
-        )
-        for option in wavefunction_options:
-            if option not in valid_options:
-                raise ValueError(
-                    f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
-                )
-        # Default options
-        self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
-        self.wavefunction_options.setdefault("include_active_kappa", True)
-        self.wavefunction_options.setdefault("do_pp", False)
         if len(active_space) != 2:
             raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
         if isinstance(active_space[0], int):
@@ -137,12 +115,9 @@ class WaveFunctionUPS:
         self.num_energy_evals = 0
         self._c_mo = mo_coeffs
         # Reference wave function
-        self._pp = self.wavefunction_options["do_pp"]
-        if self.wavefunction_options["do_pp"]:
-            if "reference_determinant" in self.wavefunction_options.keys():
-                raise ValueError(
-                    "Both 'do_pp' and 'reference_determinant' are requested in 'wavefunction_options'."
-                )
+        if do_pp:
+            if reference_determinant is not None:
+                raise ValueError("Both 'do_pp' and 'reference_determinant'.")
             if self.num_active_elec_alpha != self.num_active_elec_beta:
                 raise ValueError(
                     "perfect-pairing is only defined for equal number of alpha and beta electrons."
@@ -182,15 +157,15 @@ class WaveFunctionUPS:
             self._c_mo = pp_mo_coeffs
 
             ref_det = pp_det
-        elif "reference_determinant" in self.wavefunction_options.keys():
-            ref_det = self.wavefunction_options["reference_determinant"]
+        elif reference_determinant is not None:
+            ref_det = reference_determinant
             if len(ref_det) != self.num_active_spin_orbs:
                 raise ValueError(
                     f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
                 )
             ref_alpha = 0
             ref_beta = 0
-            for i, idx in ref_det:
+            for i, idx in enumerate(ref_det):
                 if i % 2 == 0 and idx == "1":
                     ref_alpha += 1
                 elif idx == "1":
@@ -242,16 +217,16 @@ class WaveFunctionUPS:
                 self.active_occ_idx.append(orb_idx)
             elif ref_det[2 * i] == "0" and ref_det[2 * i + 1] == "0":
                 self.active_unocc_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "both":
+            elif resolve_unpaired_idx == "both":
                 self.active_occ_idx.append(orb_idx)
                 self.active_unocc_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
+            elif resolve_unpaired_idx == "occ":
                 self.active_occ_idx.append(orb_idx)
-            elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
+            elif resolve_unpaired_idx == "unocc":
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {resolve_unpaired_idx}, excepted 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -270,7 +245,7 @@ class WaveFunctionUPS:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
                     continue
-                if not self.wavefunction_options["include_active_kappa"]:
+                if not include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
                         continue
                 if not (p in self.active_idx and q in self.active_idx):
@@ -306,7 +281,7 @@ class WaveFunctionUPS:
         self.ref_coeffs = np.zeros(self.num_det, dtype=float)
         print("Reference (active) determinant:", ref_det)
         self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
-        self.ci_coeffs = np.copy(self.ref_coeffs)
+        self._ci_coeffs = np.copy(self.ref_coeffs)
         # Construct UPS Structure
         self.ups_layout = UpsStructure()
         if ansatz.lower() in ("tups", "qnp"):
@@ -316,6 +291,8 @@ class WaveFunctionUPS:
                 self.ansatz_options["do_qnp"] = True
             self.ups_layout.create_tiled(self.num_active_orbs, self.ansatz_options)
         elif ansatz.lower() in ("fucc", "fuccsd", "ksafupccgsd", "fuccpd", "safuccsd"):
+            # Default options
+            self.ansatz_options.setdefault("n_layers", 1)
             self.ansatz_options.setdefault("excitations", [])
             if ansatz.lower() == "fuccsd":
                 self.ansatz_options["excitations"].append("S")
@@ -328,8 +305,6 @@ class WaveFunctionUPS:
             elif ansatz.lower() == "safuccspd":
                 self.ansatz_options["excitations"].append("SAS")
                 self.ansatz_options["excitations"].append("SAD")
-            # Default options
-            self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_fUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -339,13 +314,13 @@ class WaveFunctionUPS:
                 self.ansatz_options,
             )
         elif ansatz.lower() in ("sdsfuccsd", "ksasdsfupccgsd"):
+            # Default options
+            self.ansatz_options.setdefault("n_layers", 1)
             self.ansatz_options.setdefault("excitations", [])
             if ansatz.lower() == "sdsfuccsd":
                 self.ansatz_options["excitations"].append("D")
             elif ansatz.lower() == "ksasdsfupccgsd":
                 self.ansatz_options["excitations"].append("GpD")
-            # Default options
-            self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_SDSfUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -358,8 +333,9 @@ class WaveFunctionUPS:
             raise ValueError(f"Got unknown ansatz, {ansatz}")
         self._thetas = np.zeros(self.ups_layout.n_params).tolist()
         # Used when converting to circuit wavefunction.
-        self._include_active_kappa = self.wavefunction_options["include_active_kappa"]
+        self._include_active_kappa = include_active_kappa
         self._ref_det = ref_det
+        self._resolve_unpaired_idx = resolve_unpaired_idx
 
     @property
     def kappa(self) -> list[float]:
@@ -380,6 +356,22 @@ class WaveFunctionUPS:
         # Move current expansion point.
         self._c_mo = self.c_mo
         self._kappa_old = self.kappa
+
+    @property
+    def ci_coeffs(self) -> np.ndarray:
+        """Get CI coefficients.
+
+        Returns:
+            State vector.
+        """
+        if self._ci_coeffs is None:
+            self._ci_coeffs = construct_ups_state(
+                self.ref_coeffs,
+                self.ci_info,
+                self.thetas,
+                self.ups_layout,
+            )
+        return self._ci_coeffs
 
     @property
     def thetas(self) -> list[float]:
@@ -404,13 +396,8 @@ class WaveFunctionUPS:
         self._rdm3 = None
         self._rdm4 = None
         self._energy_elec = None
+        self._ci_coeffs = None
         self._thetas = theta_vals.copy()
-        self.ci_coeffs = construct_ups_state(
-            self.ref_coeffs,
-            self.ci_info,
-            self.thetas,
-            self.ups_layout,
-        )
 
     @property
     def c_mo(self) -> np.ndarray:
@@ -750,104 +737,78 @@ class WaveFunctionUPS:
 
     def run_wf_optimization(
         self,
-        orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
-        optimization_options: dict[str, Any] | None = None,
+        orbital_optimization: bool = False,
+        theta_optimization: bool = True,
+        one_step_optimizer: str = "BFGS",
+        theta_optimizer: str = "BFGS",
+        orbital_optimizer: str = "BFGS",
+        opt_type: str = "1step",
+        is_silent_subiterations: bool = False,
     ) -> None:
         """Run variational optimization of wavefunction.
 
-        Optimization options:
-            * theta_optimization [bool]: Perform theta optimization.
-                                         (default: True)
-            * theta_optimizer [str]: Optimizer used for theta optimization.
-                                     (default: BFGS)
-            * orbital_optimizer [str]: Optimizer used for orbital optimization.
-                                     (default: BFGS)
-            * 1step_optimizer [str]: Optimizer used for 1step optimizer.
-                                     (fallback: copy theta_optimizer)
-            * opt_type [str]: Optimization type, can be '1step' or '2step'.
-                              (default: 1step)
-            * is_silent_subiterations [bool]: Silence sub iterations in 2step.
-                                              (default: False)
-
         Args:
-            orbital_optimization: Perform orbital optimization.
             tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            optimization_options: Additional optimization options.
+            orbital_optimization: Perform orbital optimization.
+            theta_optimization: Perform theta optimization.
+            one_step_optimizer: Optimizer used for 1step optimizer.
+            theta_optimizer: Optimizer used for theta optimization in 2step optimizer.
+            orbital_optimizer: Optimizer used for orbital optimization in 2step optimizer.
+            opt_type: Optimization type, can be '1step' or '2step'.
+            is_silent_subiterations: Silence sub iterations in 2step.
         """
-        if optimization_options is None:
-            optimization_options = {}
-        self._optimization_options = copy.deepcopy(optimization_options)
-        valid_options = (
-            "theta_optimization",
-            "theta_optimizer",
-            "orbital_optimizer",
-            "opt_type",
-            "is_silent_subiterations",
-            "1step_optimizer",
-        )
-        for option in self._optimization_options:
-            if option not in valid_options:
-                raise ValueError(
-                    f"Got unknown option for optimization, {option}. Valid options are: {valid_options}"
-                )
-        self._optimization_options["tol"] = tol
-        self._optimization_options["maxiter"] = int(maxiter)
-        self._optimization_options["orbital_optimization"] = orbital_optimization
-        self._optimization_options.setdefault("theta_optimization", True)
-        self._optimization_options.setdefault("theta_optimizer", "BFGS")
-        self._optimization_options.setdefault("orbital_optimizer", "BFGS")
-        self._optimization_options.setdefault("opt_type", "1step")
-        self._optimization_options.setdefault("is_silent_subiterations", False)
-        if len(self.kappa) == 0 and self._optimization_options["orbital_optimization"]:
+        if len(self.kappa) == 0 and orbital_optimization:
             print("No kappa parameters turning off orbital optimization.")
-        if len(self.thetas) == 0 and self._optimization_options["theta_optimization"]:
+            orbital_optimization = False
+        if len(self.thetas) == 0 and theta_optimization:
             print("No thetas parameters turning off theta optimization.")
-        if self._optimization_options["opt_type"].lower() == "2step" and (
-            not self._optimization_options["orbital_optimization"]
-            or not self._optimization_options["theta_optimization"]
-        ):
-            if not self._optimization_options["orbital_optimization"]:
+            theta_optimization = False
+        if opt_type.lower() == "2step" and (not orbital_optimization or not theta_optimization):
+            if not orbital_optimization:
                 print("Orbital optimization not requested changing optimizer type to 1step.")
-                self._optimization_options["opt_type"] = "1step"
-            elif not self._optimization_options["theta_optimization"]:
+                opt_type = "1step"
+            elif not theta_optimization:
                 print("theta optimization not requested changing optimizer type to 1step.")
-                self._optimization_options["opt_type"] = "1step"
-        if (
-            self._optimization_options["opt_type"].lower() == "1step"
-            and "1step_optimizer" not in self._optimization_options.keys()
-        ):
-            print(
-                f"'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
-            )
-            self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
+                opt_type = "1step"
         print("### Parameters information:")
-        if self._optimization_options["orbital_optimization"]:
+        if orbital_optimization:
             print(f"### Number kappa: {len(self.kappa)}")
-        if self._optimization_options["theta_optimization"]:
+        if theta_optimization:
             print(f"### Number theta: {self.ups_layout.n_params}")
-        if self._optimization_options["opt_type"].lower() == "1step":
-            self._run_wf_optimization_1step()
-        elif self._optimization_options["opt_type"].lower() == "2step":
-            self._run_wf_optimization_2step()
-        else:
-            raise ValueError(
-                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excpected '1step' or '2step'."
+        if opt_type.lower() == "1step":
+            self._run_wf_optimization_1step(
+                tol, maxiter, orbital_optimization, theta_optimization, one_step_optimizer
             )
+        elif opt_type.lower() == "2step":
+            self._run_wf_optimization_2step(
+                tol, maxiter, theta_optimizer, orbital_optimizer, is_silent_subiterations
+            )
+        else:
+            raise ValueError(f"Got unknown 'opt_type', {opt_type} excpected '1step' or '2step'.")
 
     def _run_wf_optimization_2step(
         self,
+        tol: float,
+        maxiter: int,
+        theta_optimizer: str,
+        orbital_optimizer: str,
+        is_silent_subiterations: bool,
     ) -> None:
-        """Run two step optimization of wave function."""
+        """Run two step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        for full_iter in range(0, self._optimization_options["maxiter"]):
+        for full_iter in range(0, maxiter):
             full_start = time.time()
             # Do ansatz optimization
-            if not self._optimization_options["is_silent_subiterations"]:
+            if not is_silent_subiterations:
                 print("--------Ansatz optimization")
                 print(
                     "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
@@ -864,16 +825,16 @@ class WaveFunctionUPS:
             )
             optimizer = Optimizers(
                 energy_theta,
-                self._optimization_options["theta_optimizer"],
+                theta_optimizer,
                 grad=gradient_theta,
-                maxiter=self._optimization_options["maxiter"],
-                tol=self._optimization_options["tol"],
-                is_silent=self._optimization_options["is_silent_subiterations"],
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
                 energy_eval_callback=lambda: self.num_energy_evals,
             )
             self._old_opt_parameters = np.zeros_like(self.thetas) + 10**20
             self._E_opt_old = 0.0
-            if self._optimization_options["theta_optimizer"].lower() == "rotosolve":
+            if theta_optimizer.lower() == "rotosolve":
                 res = optimizer.minimize(
                     self.thetas,
                     extra_options={
@@ -888,7 +849,7 @@ class WaveFunctionUPS:
                 )
             self.thetas = res.x.tolist()
 
-            if not self._optimization_options["is_silent_subiterations"]:
+            if not is_silent_subiterations:
                 print("--------Orbital optimization")
                 print(
                     "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
@@ -906,11 +867,11 @@ class WaveFunctionUPS:
 
             optimizer = Optimizers(
                 energy_oo,
-                self._optimization_options["orbital_optimizer"],
+                orbital_optimizer,
                 grad=gradient_oo,
-                maxiter=self._optimization_options["maxiter"],
-                tol=self._optimization_options["tol"],
-                is_silent=self._optimization_options["is_silent_subiterations"],
+                maxiter=maxiter,
+                tol=tol,
+                is_silent=is_silent_subiterations,
                 energy_eval_callback=lambda: self.num_energy_evals,
             )
             self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
@@ -925,59 +886,41 @@ class WaveFunctionUPS:
             print(
                 f"{str(full_iter + 1).center(11)} | {time_str.center(18)} | {e_str.center(27)} | {str(self.num_energy_evals).center(11)}"
             )
-            if abs(e_new - e_old) < self._optimization_options["tol"]:
+            if abs(e_new - e_old) < tol:
                 break
             e_old = e_new
         self._energy_elec = e_new
 
     def _run_wf_optimization_1step(
         self,
+        tol: float,
+        maxiter: int,
+        orbital_optimization: bool,
+        theta_optimization: bool,
+        one_step_optimizer: str,
     ) -> None:
-        """Run one step optimization of wave function."""
-        if (
-            self._optimization_options["1step_optimizer"].lower() == "rotosolve"
-            and self._optimization_options["orbital_optimization"]
-        ):
+        """Run one step optimization of wave function.
+
+        This function should not be called from the outside.
+        See 'run_wf_optimization' for argument description.
+        """
+        if one_step_optimizer.lower() == "rotosolve" and orbital_optimization:
             raise ValueError(
                 "Cannot use RotoSolve together with orbital optimization in the one-step solver."
             )
         print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=True,
-                    kappa_optimization=True,
-                )
-            else:
-                energy = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-                gradient = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
-        else:
-            energy = partial(
-                self._calc_energy_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-            gradient = partial(
-                self._calc_gradient_optimization,
-                theta_optimization=True,
-                kappa_optimization=False,
-            )
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
+        energy = partial(
+            self._calc_energy_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        gradient = partial(
+            self._calc_gradient_optimization,
+            theta_optimization=theta_optimization,
+            kappa_optimization=orbital_optimization,
+        )
+        if orbital_optimization:
+            if theta_optimization:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
@@ -985,15 +928,15 @@ class WaveFunctionUPS:
             parameters = self.thetas
         optimizer = Optimizers(
             energy,
-            self._optimization_options["1step_optimizer"],
+            one_step_optimizer,
             grad=gradient,
-            maxiter=self._optimization_options["maxiter"],
-            tol=self._optimization_options["tol"],
+            maxiter=maxiter,
+            tol=tol,
             energy_eval_callback=lambda: self.num_energy_evals,
         )
         self._old_opt_parameters = np.zeros_like(parameters) + 10**20
         self._E_opt_old = 0.0
-        if self._optimization_options["1step_optimizer"].lower() == "rotosolve":
+        if one_step_optimizer.lower() == "rotosolve":
             res = optimizer.minimize(
                 parameters,
                 extra_options={
@@ -1006,8 +949,8 @@ class WaveFunctionUPS:
             res = optimizer.minimize(
                 parameters,
             )
-        if self._optimization_options["orbital_optimization"]:
-            if self._optimization_options["theta_optimization"]:
+        if orbital_optimization:
+            if theta_optimization:
                 self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence
 from functools import partial
 from typing import Any
 
@@ -33,132 +32,208 @@ from slowquant.unitary_coupled_cluster.operator_state_algebra import (
 from slowquant.unitary_coupled_cluster.operators import Epq, hamiltonian_0i_0a
 from slowquant.unitary_coupled_cluster.optimizers import Optimizers
 from slowquant.unitary_coupled_cluster.util import UpsStructure
+import copy
 
 
 class WaveFunctionUPS:
     def __init__(
         self,
-        cas: Sequence[int],
+        active_space: tuple[int, int] | tuple[tuple[int,int], int],
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         ansatz: str,
         ansatz_options: dict[str, Any] | None = None,
-        include_active_kappa: bool = False,
+        wavefunction_options: dict[str, Any] | None = None,
     ) -> None:
         """Initialize for UPS wave function.
 
+        Wavefunction Options:
+            * do_pp [bool]: Make perfect-pairing reference determinant.
+                            Will also reorder the orbitalers to match the determinant.
+                            (default: False)
+            * pp_no_reoder_mo [bool]: Turn off orbital reordering during pp.
+                                      (default: False)
+            * include_active_kappa [bool]: Include active-active orbital rotations.
+                                           (default: True)
+            * resolve_unpaired_idx [str]: Specify how to resolve spatial index with respect to occupation of reference determinant.
+                                          'both', include spatial index in both occ and unocc idx list.
+                                          'occ', include spatial index only in occ idx list.
+                                          'unocc', include spatial index only in unocc idx list.
+                                          (default: 'both')
+            * reference_determiant [str]: Specify a reference determinant for the active space part.
+                                          1 specifying occupied orbital and 0 specifying unoccupied orbital.
+
         Args:
-            cas: CAS(num_active_elec, num_active_orbs),
+            active_space: (num_active_elec, num_active_orbs) or ((num_active_elec_alpha, num_active_elec_beta), num_active_orbs),
                  orbitals are counted in spatial basis.
             mo_coeffs: Initial orbital coefficients.
             integral_generator: Integral generator object.
             ansatz: Name of ansatz.
             ansatz_options: Ansatz options.
-            include_active_kappa: Include active-active orbital rotations.
+            wavefunction_options: Wavefunction options.
         """
         if ansatz_options is None:
             ansatz_options = {}
-        if len(cas) != 2:
-            raise ValueError(f"cas must have two elements, got {len(cas)} elements.")
+        self.ansatz_options = copy.deepcopy(ansatz_options)
+        if wavefunction_options is None:
+            wavefunction_options = {}
+        self.wavefunction_options = copy.deepcopy(wavefunction_options)
+        valid_options = ("do_pp", "resolve_unpaired_idx", "include_active_kappa", "reference_determiant", "pp_no_reoder_mo")
+        for option in wavefunction_options:
+            if option not in wavefunction_options:
+                raise ValueError(f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}")
+        # Default options
+        self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
+        self.wavefunction_options.setdefault("include_active_kappa", True)
+        self.wavefunction_options.setdefault("do_pp", False)
+        self.wavefunction_options.setdefault("pp_no_reoder_mo", False)
+        if len(active_space) != 2:
+            raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
+        if isinstance(active_space[0], int):
+            if active_space[0]%2 == 0:
+                cas = ((active_space[0]//2, active_space[0]//2), active_space[1])
+            else:
+                # Uneven number of electrons mean one electron must be unpaired.
+                cas = ((active_space[0]//2 + 1, active_space[0]//2), active_space[1])
+        else:
+            cas = ((active_space[0][0], active_space[0][1]), active_space[1])
         # Init stuff
         self.int_gen = IntegralManager(integral_generator)
-        self.inactive_spin_idx = []
-        self.virtual_spin_idx = []
-        self.active_spin_idx = []
-        self.active_occ_spin_idx = []
-        self.active_unocc_spin_idx = []
-        self.active_spin_idx_shifted = []
-        self.active_occ_spin_idx_shifted = []
-        self.active_unocc_spin_idx_shifted = []
-        self.active_idx_shifted = []
-        self.active_occ_idx_shifted = []
-        self.active_unocc_idx_shifted = []
-        self.num_spin_orbs = 2 * len(self.int_gen.kinetic_energy)
-        self.num_orbs = len(self.int_gen.kinetic_energy)
-        self.num_active_elec = 0
-        self.num_active_spin_orbs = 0
-        self.num_inactive_spin_orbs = 0
-        self.num_virtual_spin_orbs = 0
+        if np.sum(cas[0]) > self.int_gen.num_elec:
+            raise ValueError("More active electrons than total number electrons.")
+        if (np.sum(cas[0])%2 == 0 and self.int_gen.num_elec%2 == 1) or (np.sum(cas[0])%2 == 1 and self.int_gen.num_elec%2 == 0):
+            raise ValueError("Specified CAS gives odd number of electrons in inactive space.")
+        self.num_inactive_spin_orbs = self.int_gen.num_elec - int(np.sum(cas[0]))
+        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
+        self.num_active_orbs = cas[1]
+        self.num_active_spin_orbs = 2*self.num_active_orbs
+        self.num_active_orbs = self.num_active_spin_orbs // 2
+        self.num_virtual_orbs = len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
+        if self.num_virtual_orbs < 0:
+            raise ValueError("Number of inactive + number of active orbitals is larger than total number of orbitals.")
+        self.num_virtual_spin_orbs = 2*self.num_virtual_orbs
+        self.num_orbs = self.num_inactive_orbs + self.num_active_orbs + self.num_virtual_orbs
+        self.num_spin_orbs = 2*self.num_orbs
+        self.num_active_elec_alpha = cas[0][0]
+        self.num_active_elec_beta = cas[0][1]
+        self.num_active_elec = self.num_active_elec_alpha + self.num_active_elec_beta
         self._rdm1 = None
         self._rdm2 = None
+        self._rdm3 = None
+        self._rdm4 = None
         self._h_mo = None
         self._g_mo = None
         self._energy_elec: float | None = None
-        self.ansatz_options = ansatz_options
         self.num_energy_evals = 0
+        self._c_mo = mo_coeffs
         # Used when converting to circuit wavefunction.
-        self._include_active_kappa = include_active_kappa
-        # Construct spin orbital spaces and indices
-        active_space = []
-        orbital_counter = 0
-        num_elec = self.int_gen.num_elec
-        for i in range(num_elec - cas[0], num_elec):
-            active_space.append(i)
-            orbital_counter += 1
-        for i in range(num_elec, num_elec + 2 * cas[1] - orbital_counter):
-            active_space.append(i)
-        for i in range(num_elec):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_occ_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-                self.num_active_elec += 1
+        self._include_active_kappa = self.wavefunction_options["include_active_kappa"]
+        # Reference wave function
+        self._pp = self.wavefunction_options["do_pp"]
+        if self.wavefunction_options["do_pp"]:
+            if "reference_determiant" in self.wavefunction_options.keys():
+                raise ValueError("Both 'do_pp' and 'reference_determiant' are requested in 'wavefunction_options'.")
+            if self.num_active_elec_alpha != self.num_active_elec_beta:
+                raise ValueError("perfect-pairing is only defined for equal number of alpha and beta electrons.")
+            # Obtain pp determinant
+            pp_det = ""
+            spin_orb = 0
+            elec_count = self.num_active_elec
+            while spin_orb < self.num_active_spin_orbs:
+                if (
+                    elec_count >= 2
+                    and (self.num_active_spin_orbs - spin_orb) >= 4
+                    and elec_count <= (self.num_active_spin_orbs - spin_orb - 2)
+                ):
+                    pp_det += "1100"
+                    elec_count -= 2
+                    spin_orb += 4
+                elif elec_count == 0:
+                    pp_det += "0"
+                    spin_orb += 1
+                elif elec_count != 0:
+                    pp_det += "1"
+                    spin_orb += 1
+                    elec_count -= 1
+            if len(pp_det) != self.num_active_spin_orbs or pp_det.count("1") != self.num_active_elec:
+                raise ValueError("Perfect pairing determinant violates orbital or electron numbers")
+
+            # Swap mo coefficients to resembles pp layout
+            if not self.wavefunction_options["pp_no_reoder_mo"]:
+                hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
+                hole = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "1" and p == "0"]
+                part = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "0" and p == "1"]
+                hole_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in hole))
+                part_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in part))
+                pp_mo_coeffs = mo_coeffs.copy()
+                pp_mo_coeffs[:, hole_spatial + part_spatial] = pp_mo_coeffs[:, part_spatial + hole_spatial]
+                # Note self._c_mo is set previously but overwritten here.
+                self._c_mo = pp_mo_coeffs
+
+            # Assign weight to reference
+            ref_det = pp_det
+        elif "reference_determiant" in self.wavefunction_options.keys():
+            ref_det = self.wavefunction_options["reference_determiant"]
+            if len(ref_det) != self.num_active_spin_orbs:
+                raise ValueError(f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals.")
+            ref_alpha = 0
+            ref_beta = 0
+            for i, idx in ref_det:
+                if i%2 == 0 and idx == "1":
+                    ref_alpha += 1
+                elif idx == "1":
+                    ref_beta += 1
+            if ref_alpha != self.num_active_elec_alpha or ref_beta != self.num_active_elec_beta:
+                raise ValueError("Number of electrons ({ref_alpha}, {ref_beta}) is different from the active space ({self.num_active_elec_alpha, self.num_active_elec_beta}).")
+        else:
+            ref_det = ""
+            for i in range(self.num_active_orbs):
+                if i < self.num_active_elec_alpha:
+                    ref_det += "1"
+                else:
+                    ref_det += "0"
+                if i < self.num_active_elec_beta: 
+                    ref_det += "1"
+                else:
+                    ref_det += "0"
+        # Construct spin orbital indices
+        self.inactive_spin_idx = [x for x in range(self.num_inactive_spin_orbs)]
+        self.active_spin_idx = [x + self.num_inactive_spin_orbs for x in range(self.num_active_spin_orbs)]
+        self.virtual_spin_idx = [x + self.num_inactive_spin_orbs + self.num_active_spin_orbs for x in range(self.num_virtual_spin_orbs)]
+        self.active_occ_spin_idx = []
+        self.active_unocc_spin_idx = []
+        for i, orb_idx in enumerate(self.active_spin_idx):
+            if ref_det[i] == "1":
+                self.active_occ_spin_idx.append(orb_idx)
             else:
-                self.inactive_spin_idx.append(i)
-                self.num_inactive_spin_orbs += 1
-        for i in range(num_elec, self.num_spin_orbs):
-            if i in active_space:
-                self.active_spin_idx.append(i)
-                self.active_unocc_spin_idx.append(i)
-                self.num_active_spin_orbs += 1
-            else:
-                self.virtual_spin_idx.append(i)
-                self.num_virtual_spin_orbs += 1
-        if self.num_active_elec % 2 != 0:
-            raise ValueError("Number of active electrons has to be even")
-        self.num_active_elec_alpha = self.num_active_elec // 2
-        self.num_active_elec_beta = self.num_active_elec // 2
-        self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
-        self.num_active_orbs = self.num_active_spin_orbs // 2
-        self.num_virtual_orbs = self.num_virtual_spin_orbs // 2
+                self.active_unocc_spin_idx.append(orb_idx)
+        self.active_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_spin_idx]
+        self.active_occ_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_occ_spin_idx]
+        self.active_unocc_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_unocc_spin_idx]
         # Construct spatial idx
-        self.inactive_idx: list[int] = []
-        self.virtual_idx: list[int] = []
-        self.active_idx: list[int] = []
-        self.active_occ_idx: list[int] = []
-        self.active_unocc_idx: list[int] = []
-        for idx in self.inactive_spin_idx:
-            if idx // 2 not in self.inactive_idx:
-                self.inactive_idx.append(idx // 2)
-        for idx in self.active_spin_idx:
-            if idx // 2 not in self.active_idx:
-                self.active_idx.append(idx // 2)
-        for idx in self.virtual_spin_idx:
-            if idx // 2 not in self.virtual_idx:
-                self.virtual_idx.append(idx // 2)
-        for idx in self.active_occ_spin_idx:
-            if idx // 2 not in self.active_occ_idx:
-                self.active_occ_idx.append(idx // 2)
-        for idx in self.active_unocc_spin_idx:
-            if idx // 2 not in self.active_unocc_idx:
-                self.active_unocc_idx.append(idx // 2)
-        # Make shifted indices
-        if len(self.active_spin_idx) != 0:
-            active_shift = np.min(self.active_spin_idx)
-            for active_idx in self.active_spin_idx:
-                self.active_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_spin_idx:
-                self.active_occ_spin_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_spin_idx:
-                self.active_unocc_spin_idx_shifted.append(active_idx - active_shift)
-        if len(self.active_idx) != 0:
-            active_shift = np.min(self.active_idx)
-            for active_idx in self.active_idx:
-                self.active_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_occ_idx:
-                self.active_occ_idx_shifted.append(active_idx - active_shift)
-            for active_idx in self.active_unocc_idx:
-                self.active_unocc_idx_shifted.append(active_idx - active_shift)
+        self.inactive_idx = [x for x in range(self.num_inactive_orbs)]
+        self.active_idx = [x + self.num_inactive_orbs for x in range(self.num_active_orbs)]
+        self.virtual_idx = [x + self.num_inactive_orbs + self.num_active_orbs for x in range(self.num_virtual_orbs)]
+        self.active_occ_idx = []
+        self.active_unocc_idx = []
+        for i, orb_idx in enumerate(self.active_idx):
+            if ref_det[2*i] == "1" and ref_det[2*i+1] == "1":
+                self.active_occ_idx.append(orb_idx)
+            elif ref_det[2*i] == "0" and ref_det[2*i+1] == "0":
+                self.active_unocc_idx.append(orb_idx)
+            else:
+                if self.wavefunction_options["resolve_unpaired_idx"] == "both":
+                    self.active_occ_idx.append(orb_idx)
+                    self.active_unocc_idx.append(orb_idx)
+                elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
+                    self.active_occ_idx.append(orb_idx)
+                elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
+                    self.active_unocc_idx.append(orb_idx)
+                else:
+                    raise ValueError(f"Got unknown option for resolve_unpaired_idx, {ansatz_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'.")
+        self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
+        self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
+        self.active_unocc_idx_shifted = [x - self.num_inactive_orbs for x in self.active_unocc_idx]
         # Find non-redundant kappas
         self._kappa = []
         kappa_idx = []
@@ -177,7 +252,7 @@ class WaveFunctionUPS:
                 if p in self.virtual_idx and q in self.virtual_idx:
                     kappa_redundant_idx.append((p, q))
                     continue
-                if not include_active_kappa:
+                if not self._include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
                         kappa_redundant_idx.append((p, q))
                         continue
@@ -212,56 +287,10 @@ class WaveFunctionUPS:
             self.num_active_elec_beta,
         )
         self.num_det = len(self.ci_info.idx2det)
-        self.csf_coeffs = np.zeros(self.num_det)
-
-        hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
-        self._pp = False
-        if (
-            ansatz.lower() == "tups"
-            and "do_pp" in self.ansatz_options.keys()
-            and self.ansatz_options["do_pp"]
-        ):
-            # Obtain pp determinant
-            pp_det = ""
-            spin_orb = 0
-            elec_count = self.num_active_elec
-            while spin_orb < self.num_active_spin_orbs:
-                if (
-                    elec_count >= 2
-                    and (self.num_active_spin_orbs - spin_orb) >= 4
-                    and elec_count <= (self.num_active_spin_orbs - spin_orb - 2)
-                ):
-                    pp_det += "1100"
-                    elec_count -= 2
-                    spin_orb += 4
-                elif elec_count == 0:
-                    pp_det += "0"
-                    spin_orb += 1
-                elif elec_count != 0:
-                    pp_det += "1"
-                    spin_orb += 1
-                    elec_count -= 1
-            print("perfect-pairing determinant found as:", pp_det)
-            if len(pp_det) != self.num_active_spin_orbs or pp_det.count("1") != self.num_active_elec:
-                raise ValueError("Perfect pairing determinant violates orbital or electron numbers")
-
-            # Swap mo coefficients to resembles pp layout
-            hole = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "1" and p == "0"]
-            part = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "0" and p == "1"]
-            hole_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in hole))
-            part_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in part))
-            pp_mo_coeffs = mo_coeffs.copy()
-            pp_mo_coeffs[:, hole_spatial + part_spatial] = pp_mo_coeffs[:, part_spatial + hole_spatial]
-            self._c_mo = pp_mo_coeffs
-
-            # Assign weight to reference
-            self.csf_coeffs[self.ci_info.det2idx[int(pp_det, 2)]] = 1
-            self._pp = True
-        else:
-            self.csf_coeffs[self.ci_info.det2idx[int(hf_det, 2)]] = 1
-            self._c_mo = mo_coeffs
-
-        self.ci_coeffs = np.copy(self.csf_coeffs)
+        self.ref_coeffs = np.zeros(self.num_det, dtype=float)
+        print("Reference (active) determinant:", ref_det)
+        self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
+        self.ci_coeffs = np.copy(self.ref_coeffs)
         # Construct UPS Structure
         self.ups_layout = UpsStructure()
         if ansatz.lower() in ("tups", "qnp"):
@@ -282,9 +311,8 @@ class WaveFunctionUPS:
             elif ansatz.lower() == "safuccspd":
                 self.ansatz_options["SAS"] = True
                 self.ansatz_options["SAD"] = True
-            if "n_layers" not in self.ansatz_options.keys():
-                # default option
-                self.ansatz_options["n_layers"] = 1
+            # Default options
+            self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_fUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -298,9 +326,8 @@ class WaveFunctionUPS:
                 self.ansatz_options["D"] = True
             elif ansatz.lower() == "ksasdsfupccgsd":
                 self.ansatz_options["GpD"] = True
-            if "n_layers" not in self.ansatz_options.keys():
-                # default option
-                self.ansatz_options["n_layers"] = 1
+            # Default options
+            self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_SDSfUCC(
                 self.active_occ_idx_shifted,
                 self.active_unocc_idx_shifted,
@@ -358,7 +385,7 @@ class WaveFunctionUPS:
         self._energy_elec = None
         self._thetas = theta_vals.copy()
         self.ci_coeffs = construct_ups_state(
-            self.csf_coeffs,
+            self.ref_coeffs,
             self.ci_info,
             self.thetas,
             self.ups_layout,
@@ -1108,8 +1135,8 @@ class WaveFunctionUPS:
                 dagger=True,
             )
             # CSF reference state on ket
-            ket_vec = np.copy(self.csf_coeffs)
-            ket_vec_tmp = np.copy(self.csf_coeffs)
+            ket_vec = np.copy(self.ref_coeffs)
+            ket_vec_tmp = np.copy(self.ref_coeffs)
             # Calculate analytical derivative w.r.t. each theta using gradient_action function
             for i in range(len(self.thetas)):
                 # Derivative action w.r.t. i-th theta on CSF ket
@@ -1161,7 +1188,7 @@ class WaveFunctionUPS:
         thetas_local = np.asarray(parameters)
 
         # Prepare reference state up to theta_idx
-        state_vec = np.copy(self.csf_coeffs)
+        state_vec = np.copy(self.ref_coeffs)
         for i in range(0, theta_idx):
             state_vec = propagate_unitary(state_vec, i, self.ci_info, thetas_local, self.ups_layout)
 

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -51,8 +51,6 @@ class WaveFunctionUPS:
             * do_pp [bool]: Make perfect-pairing reference determinant.
                             Will also reorder the orbitalers to match the determinant.
                             (default: False)
-            * pp_no_reoder_mo [bool]: Turn off orbital reordering during pp.
-                                      (default: False)
             * include_active_kappa [bool]: Include active-active orbital rotations.
                                            (default: True)
             * resolve_unpaired_idx [str]: Specify how to resolve spatial index with respect to occupation of reference determinant.
@@ -83,10 +81,9 @@ class WaveFunctionUPS:
             "resolve_unpaired_idx",
             "include_active_kappa",
             "reference_determiant",
-            "pp_no_reoder_mo",
         )
         for option in wavefunction_options:
-            if option not in wavefunction_options:
+            if option not in valid_options:
                 raise ValueError(
                     f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
                 )
@@ -94,7 +91,6 @@ class WaveFunctionUPS:
         self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
         self.wavefunction_options.setdefault("include_active_kappa", True)
         self.wavefunction_options.setdefault("do_pp", False)
-        self.wavefunction_options.setdefault("pp_no_reoder_mo", False)
         if len(active_space) != 2:
             raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
         if isinstance(active_space[0], int):
@@ -140,8 +136,6 @@ class WaveFunctionUPS:
         self._energy_elec: float | None = None
         self.num_energy_evals = 0
         self._c_mo = mo_coeffs
-        # Used when converting to circuit wavefunction.
-        self._include_active_kappa = self.wavefunction_options["include_active_kappa"]
         # Reference wave function
         self._pp = self.wavefunction_options["do_pp"]
         if self.wavefunction_options["do_pp"]:
@@ -177,16 +171,15 @@ class WaveFunctionUPS:
                 raise ValueError("Perfect pairing determinant violates orbital or electron numbers")
 
             # Swap mo coefficients to resembles pp layout
-            if not self.wavefunction_options["pp_no_reoder_mo"]:
-                hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
-                hole = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "1" and p == "0"]
-                part = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "0" and p == "1"]
-                hole_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in hole))
-                part_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in part))
-                pp_mo_coeffs = mo_coeffs.copy()
-                pp_mo_coeffs[:, hole_spatial + part_spatial] = pp_mo_coeffs[:, part_spatial + hole_spatial]
-                # Note self._c_mo is set previously but overwritten here.
-                self._c_mo = pp_mo_coeffs
+            hf_det = "1" * self.num_active_elec + "0" * (self.num_active_spin_orbs - self.num_active_elec)
+            hole = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "1" and p == "0"]
+            part = [i for i, (h, p) in enumerate(zip(hf_det, pp_det)) if h == "0" and p == "1"]
+            hole_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in hole))
+            part_spatial = sorted(set(i // 2 + self.num_inactive_orbs for i in part))
+            pp_mo_coeffs = mo_coeffs.copy()
+            pp_mo_coeffs[:, hole_spatial + part_spatial] = pp_mo_coeffs[:, part_spatial + hole_spatial]
+            # Note self._c_mo is set previously but overwritten here.
+            self._c_mo = pp_mo_coeffs
 
             # Assign weight to reference
             ref_det = pp_det
@@ -279,7 +272,7 @@ class WaveFunctionUPS:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
                     continue
-                if not self._include_active_kappa:
+                if not self.wavefunction_options["include_active_kappa"]:
                     if p in self.active_idx and q in self.active_idx:
                         continue
                 if not (p in self.active_idx and q in self.active_idx):
@@ -364,6 +357,9 @@ class WaveFunctionUPS:
         else:
             raise ValueError(f"Got unknown ansatz, {ansatz}")
         self._thetas = np.zeros(self.ups_layout.n_params).tolist()
+        # Used when converting to circuit wavefunction.
+        self._include_active_kappa = self.wavefunction_options["include_active_kappa"]
+        self._ref_det = ref_det
 
     @property
     def kappa(self) -> list[float]:
@@ -752,35 +748,105 @@ class WaveFunctionUPS:
             return H.get_qiskit_form(self.num_active_orbs)
         return H
 
-    def run_wf_optimization_2step(
+    def run_wf_optimization(
         self,
-        optimizer_name: str,
         orbital_optimization: bool = False,
         tol: float = 1e-10,
         maxiter: int = 1000,
-        is_silent_subiterations: bool = False,
+        optimization_options: dict[str, Any] | None = None,
     ) -> None:
-        """Run two step optimization of wave function.
+        """Run variational optimization of wavefunction.
+
+        Optimization options:
+            * theta_optimization [bool]: Perform theta optimization.
+                                         (default: True)
+            * theta_optimizer [str]: Optimizer used for theta optimization.
+                                     (default: BFGS)
+            * orbital_optimizer [str]: Optimizer used for orbital optimization.
+                                     (default: BFGS)
+            * 1step_optimizer [str]: Optimizer used for 1step optimizer.
+                                     (fallback: copy theta_optimizer)
+            * opt_type [str]: Optimization type, can be '1step' or '2step'.
+                              (default: 1step)
+            * is_silent_subiterations [bool]: Silence sub iterations in 2step.
+                                              (default: False)
 
         Args:
-            optimizer_name: Name of optimizer.
             orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
+            tol: Tolerance for finishing the optimization.
             maxiter: Maximum number of iterations.
-            is_silent_subiterations: Silence subiterations.
+            optimization_options: Additional optimization options.
         """
+        if optimization_options is None:
+            optimization_options = {}
+        self._optimization_options = copy.deepcopy(optimization_options)
+        valid_options = (
+            "theta_optimization",
+            "theta_optimizer",
+            "orbital_optimizer",
+            "opt_type",
+            "is_silent_subiterations",
+            "1step_optimizer",
+        )
+        for option in self._optimization_options:
+            if option not in valid_options:
+                raise ValueError(
+                    f"Got unknown option for optimization, {option}. Valid options are: {valid_options}"
+                )
+        self._optimization_options["tol"] = tol
+        self._optimization_options["maxiter"] = int(maxiter)
+        self._optimization_options["orbital_optimization"] = orbital_optimization
+        self._optimization_options.setdefault("theta_optimization", True)
+        self._optimization_options.setdefault("theta_optimizer", "BFGS")
+        self._optimization_options.setdefault("orbital_optimizer", "BFGS")
+        self._optimization_options.setdefault("opt_type", "1step")
+        self._optimization_options.setdefault("is_silent_subiterations", False)
+        if len(self.kappa) == 0 and self._optimization_options["orbital_optimization"]:
+            print("No kappa parameters turning off orbital optimization.")
+        if len(self.thetas) == 0 and self._optimization_options["theta_optimization"]:
+            print("No thetas parameters turning off theta optimization.")
+        if self._optimization_options["opt_type"].lower() == "2step" and (
+            not self._optimization_options["orbital_optimization"]
+            or not self._optimization_options["theta_optimization"]
+        ):
+            if not self._optimization_options["orbital_optimization"]:
+                print("Orbital optimization not requested changing optimizer type to 1step.")
+                self._optimization_options["opt_type"] = "1step"
+            elif not self._optimization_options["theta_optimization"]:
+                print("theta optimization not requested changing optimizer type to 1step.")
+                self._optimization_options["opt_type"] = "1step"
+        if (
+            self._optimization_options["opt_type"].lower() == "1step"
+            and "1step_optimizer" not in self._optimization_options.keys()
+        ):
+            print(
+                "'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
+            )
         print("### Parameters information:")
-        if orbital_optimization:
+        if self._optimization_options["orbital_optimization"]:
             print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {self.ups_layout.n_params}")
+        if self._optimization_options["theta_optimization"]:
+            print(f"### Number theta: {self.ups_layout.n_params}")
+        if self._optimization_options["opt_type"].lower() == "1step":
+            self._run_wf_optimization_1step()
+        elif self._optimization_options["opt_type"].lower() == "2step":
+            self._run_wf_optimization_1step()
+        else:
+            raise ValueError(
+                f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excepted '1step' or '2step'."
+            )
+
+    def _run_wf_optimization_2step(
+        self,
+    ) -> None:
+        """Run two step optimization of wave function."""
         e_old = 1e12
         print("Full optimization")
         print("Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        for full_iter in range(0, int(maxiter)):
+        for full_iter in range(0, self._optimization_options["maxiter"]):
             full_start = time.time()
-
             # Do ansatz optimization
-            if not is_silent_subiterations:
+            if not self._optimization_options["is_silent_subiterations"]:
                 print("--------Ansatz optimization")
                 print(
                     "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
@@ -797,16 +863,16 @@ class WaveFunctionUPS:
             )
             optimizer = Optimizers(
                 energy_theta,
-                optimizer_name,
+                self._optimization_options["theta_optimizer"],
                 grad=gradient_theta,
-                maxiter=maxiter,
-                tol=tol,
-                is_silent=is_silent_subiterations,
+                maxiter=self._optimization_options["maxiter"],
+                tol=self._optimization_options["tol"],
+                is_silent=self._optimization_options["is_silent_subiterations"],
                 energy_eval_callback=lambda: self.num_energy_evals,
             )
             self._old_opt_parameters = np.zeros_like(self.thetas) + 10**20
             self._E_opt_old = 0.0
-            if optimizer_name.lower() == "rotosolve":
+            if self._optimization_options["theta_optimizer"].lower() == "rotosolve":
                 res = optimizer.minimize(
                     self.thetas,
                     extra_options={
@@ -821,86 +887,62 @@ class WaveFunctionUPS:
                 )
             self.thetas = res.x.tolist()
 
-            if orbital_optimization and len(self.kappa) != 0:
-                if not is_silent_subiterations:
-                    print("--------Orbital optimization")
-                    print(
-                        "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
-                    )
-                energy_oo = partial(
-                    self._calc_energy_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
+            if not self._optimization_options["is_silent_subiterations"]:
+                print("--------Orbital optimization")
+                print(
+                    "--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #"
                 )
-                gradient_oo = partial(
-                    self._calc_gradient_optimization,
-                    theta_optimization=False,
-                    kappa_optimization=True,
-                )
+            energy_oo = partial(
+                self._calc_energy_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
+            gradient_oo = partial(
+                self._calc_gradient_optimization,
+                theta_optimization=False,
+                kappa_optimization=True,
+            )
 
-                optimizer = Optimizers(
-                    energy_oo,
-                    "l-bfgs-b",
-                    grad=gradient_oo,
-                    maxiter=maxiter,
-                    tol=tol,
-                    is_silent=is_silent_subiterations,
-                    energy_eval_callback=lambda: self.num_energy_evals,
-                )
-                self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
-                self._E_opt_old = 0.0
-                res = optimizer.minimize([0.0] * len(self.kappa_idx))
-                for i in range(len(self.kappa)):
-                    self._kappa[i] = 0.0
-                    self._kappa_old[i] = 0.0
-            else:
-                # If there is no orbital optimization, then the algorithm is already converged.
-                e_new = res.fun
-                if orbital_optimization and len(self.kappa) == 0:
-                    print(
-                        "WARNING: No orbital optimization performed, because there is no non-redundant orbital parameters."
-                    )
-                break
-
+            optimizer = Optimizers(
+                energy_oo,
+                self._optimization_options["orbital_optimizer"],
+                grad=gradient_oo,
+                maxiter=self._optimization_options["maxiter"],
+                tol=self._optimization_options["tol"],
+                is_silent=self._optimization_options["is_silent_subiterations"],
+                energy_eval_callback=lambda: self.num_energy_evals,
+            )
+            self._old_opt_parameters = np.zeros(len(self.kappa_idx)) + 10**20
+            self._E_opt_old = 0.0
+            res = optimizer.minimize([0.0] * len(self.kappa_idx))
+            for i in range(len(self.kappa)):
+                self._kappa[i] = 0.0
+                self._kappa_old[i] = 0.0
             e_new = res.fun
             time_str = f"{time.time() - full_start:7.2f}"
             e_str = f"{e_new:3.12f}"
             print(
                 f"{str(full_iter + 1).center(11)} | {time_str.center(18)} | {e_str.center(27)} | {str(self.num_energy_evals).center(11)}"
             )
-            if abs(e_new - e_old) < tol:
+            if abs(e_new - e_old) < self._optimization_options["tol"]:
                 break
             e_old = e_new
         self._energy_elec = e_new
 
-    def run_wf_optimization_1step(
+    def _run_wf_optimization_1step(
         self,
-        optimizer_name: str,
-        orbital_optimization: bool = False,
-        tol: float = 1e-10,
-        maxiter: int = 1000,
     ) -> None:
-        """Run one step optimization of wave function.
-
-        Args:
-            optimizer_name: Name of optimizer.
-            orbital_optimization: Perform orbital optimization.
-            tol: Convergence tolerance.
-            maxiter: Maximum number of iterations.
-        """
-        print("### Parameters information:")
-        if orbital_optimization:
-            print(f"### Number kappa: {len(self.kappa)}")
-        print(f"### Number theta: {self.ups_layout.n_params}")
-        if optimizer_name.lower() == "rotosolve":
-            if orbital_optimization and len(self.kappa) != 0:
-                raise ValueError(
-                    "Cannot use RotoSolve together with orbital optimization in the one-step solver."
-                )
-
+        """Run one step optimization of wave function."""
+        if (
+            self._optimization_options["1step_optimizer"].lower() == "rotosolve"
+            and self._optimization_options["orbital_optimization"]
+        ):
+            raise ValueError(
+                "Cannot use RotoSolve together with orbital optimization in the one-step solver."
+            )
         print("--------Iteration # | Iteration time [s] | Electronic energy [Hartree] | Energy measurement #")
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
                 energy = partial(
                     self._calc_energy_optimization,
                     theta_optimization=True,
@@ -933,8 +975,8 @@ class WaveFunctionUPS:
                 theta_optimization=True,
                 kappa_optimization=False,
             )
-        if orbital_optimization:
-            if len(self.thetas) > 0:
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
                 parameters = self.kappa + self.thetas
             else:
                 parameters = self.kappa
@@ -942,15 +984,15 @@ class WaveFunctionUPS:
             parameters = self.thetas
         optimizer = Optimizers(
             energy,
-            optimizer_name,
+            self._optimization_options["1step_optimizer"],
             grad=gradient,
-            maxiter=maxiter,
-            tol=tol,
+            maxiter=self._optimization_options["maxiter"],
+            tol=self._optimization_options["tol"],
             energy_eval_callback=lambda: self.num_energy_evals,
         )
         self._old_opt_parameters = np.zeros_like(parameters) + 10**20
         self._E_opt_old = 0.0
-        if optimizer_name.lower() == "rotosolve":
+        if self._optimization_options["1step_optimizer"].lower() == "rotosolve":
             res = optimizer.minimize(
                 parameters,
                 extra_options={
@@ -963,8 +1005,9 @@ class WaveFunctionUPS:
             res = optimizer.minimize(
                 parameters,
             )
-        if orbital_optimization:
-            self.thetas = res.x[len(self.kappa) :].tolist()
+        if self._optimization_options["orbital_optimization"]:
+            if self._optimization_options["theta_optimization"]:
+                self.thetas = res.x[len(self.kappa) :].tolist()
             for i in range(len(self.kappa)):
                 self._kappa[i] = 0.0
                 self._kappa_old[i] = 0.0

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import time
 from functools import partial
 from typing import Any
@@ -32,13 +33,12 @@ from slowquant.unitary_coupled_cluster.operator_state_algebra import (
 from slowquant.unitary_coupled_cluster.operators import Epq, hamiltonian_0i_0a
 from slowquant.unitary_coupled_cluster.optimizers import Optimizers
 from slowquant.unitary_coupled_cluster.util import UpsStructure
-import copy
 
 
 class WaveFunctionUPS:
     def __init__(
         self,
-        active_space: tuple[int, int] | tuple[tuple[int,int], int],
+        active_space: tuple[int, int] | tuple[tuple[int, int], int],
         mo_coeffs: np.ndarray,
         integral_generator: SlowQuant | pyscf.gto.mole.Mole,
         ansatz: str,
@@ -78,10 +78,18 @@ class WaveFunctionUPS:
         if wavefunction_options is None:
             wavefunction_options = {}
         self.wavefunction_options = copy.deepcopy(wavefunction_options)
-        valid_options = ("do_pp", "resolve_unpaired_idx", "include_active_kappa", "reference_determiant", "pp_no_reoder_mo")
+        valid_options = (
+            "do_pp",
+            "resolve_unpaired_idx",
+            "include_active_kappa",
+            "reference_determiant",
+            "pp_no_reoder_mo",
+        )
         for option in wavefunction_options:
             if option not in wavefunction_options:
-                raise ValueError(f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}")
+                raise ValueError(
+                    f"Got unknown option for UPS wave function, {option}. Valid options are: {valid_options}"
+                )
         # Default options
         self.wavefunction_options.setdefault("resolve_unpaired_idx", "both")
         self.wavefunction_options.setdefault("include_active_kappa", True)
@@ -90,30 +98,36 @@ class WaveFunctionUPS:
         if len(active_space) != 2:
             raise ValueError(f"cas must have two elements, got {len(active_space)} elements.")
         if isinstance(active_space[0], int):
-            if active_space[0]%2 == 0:
-                cas = ((active_space[0]//2, active_space[0]//2), active_space[1])
+            if active_space[0] % 2 == 0:
+                cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
             else:
                 # Uneven number of electrons mean one electron must be unpaired.
-                cas = ((active_space[0]//2 + 1, active_space[0]//2), active_space[1])
+                cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
         else:
             cas = ((active_space[0][0], active_space[0][1]), active_space[1])
         # Init stuff
         self.int_gen = IntegralManager(integral_generator)
         if np.sum(cas[0]) > self.int_gen.num_elec:
             raise ValueError("More active electrons than total number electrons.")
-        if (np.sum(cas[0])%2 == 0 and self.int_gen.num_elec%2 == 1) or (np.sum(cas[0])%2 == 1 and self.int_gen.num_elec%2 == 0):
+        if (np.sum(cas[0]) % 2 == 0 and self.int_gen.num_elec % 2 == 1) or (
+            np.sum(cas[0]) % 2 == 1 and self.int_gen.num_elec % 2 == 0
+        ):
             raise ValueError("Specified CAS gives odd number of electrons in inactive space.")
         self.num_inactive_spin_orbs = self.int_gen.num_elec - int(np.sum(cas[0]))
         self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
         self.num_active_orbs = cas[1]
-        self.num_active_spin_orbs = 2*self.num_active_orbs
+        self.num_active_spin_orbs = 2 * self.num_active_orbs
         self.num_active_orbs = self.num_active_spin_orbs // 2
-        self.num_virtual_orbs = len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
+        self.num_virtual_orbs = (
+            len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
+        )
         if self.num_virtual_orbs < 0:
-            raise ValueError("Number of inactive + number of active orbitals is larger than total number of orbitals.")
-        self.num_virtual_spin_orbs = 2*self.num_virtual_orbs
+            raise ValueError(
+                "Number of inactive + number of active orbitals is larger than total number of orbitals."
+            )
+        self.num_virtual_spin_orbs = 2 * self.num_virtual_orbs
         self.num_orbs = self.num_inactive_orbs + self.num_active_orbs + self.num_virtual_orbs
-        self.num_spin_orbs = 2*self.num_orbs
+        self.num_spin_orbs = 2 * self.num_orbs
         self.num_active_elec_alpha = cas[0][0]
         self.num_active_elec_beta = cas[0][1]
         self.num_active_elec = self.num_active_elec_alpha + self.num_active_elec_beta
@@ -132,9 +146,13 @@ class WaveFunctionUPS:
         self._pp = self.wavefunction_options["do_pp"]
         if self.wavefunction_options["do_pp"]:
             if "reference_determiant" in self.wavefunction_options.keys():
-                raise ValueError("Both 'do_pp' and 'reference_determiant' are requested in 'wavefunction_options'.")
+                raise ValueError(
+                    "Both 'do_pp' and 'reference_determiant' are requested in 'wavefunction_options'."
+                )
             if self.num_active_elec_alpha != self.num_active_elec_beta:
-                raise ValueError("perfect-pairing is only defined for equal number of alpha and beta electrons.")
+                raise ValueError(
+                    "perfect-pairing is only defined for equal number of alpha and beta electrons."
+                )
             # Obtain pp determinant
             pp_det = ""
             spin_orb = 0
@@ -175,16 +193,20 @@ class WaveFunctionUPS:
         elif "reference_determiant" in self.wavefunction_options.keys():
             ref_det = self.wavefunction_options["reference_determiant"]
             if len(ref_det) != self.num_active_spin_orbs:
-                raise ValueError(f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals.")
+                raise ValueError(
+                    f"Reference determinant is {len(ref_det)} spin orbitals and the active space is {self.num_active_spin_orbs} spin orbitals."
+                )
             ref_alpha = 0
             ref_beta = 0
             for i, idx in ref_det:
-                if i%2 == 0 and idx == "1":
+                if i % 2 == 0 and idx == "1":
                     ref_alpha += 1
                 elif idx == "1":
                     ref_beta += 1
             if ref_alpha != self.num_active_elec_alpha or ref_beta != self.num_active_elec_beta:
-                raise ValueError("Number of electrons ({ref_alpha}, {ref_beta}) is different from the active space ({self.num_active_elec_alpha, self.num_active_elec_beta}).")
+                raise ValueError(
+                    "Number of electrons ({ref_alpha}, {ref_beta}) is different from the active space ({self.num_active_elec_alpha, self.num_active_elec_beta})."
+                )
         else:
             ref_det = ""
             for i in range(self.num_active_orbs):
@@ -192,14 +214,17 @@ class WaveFunctionUPS:
                     ref_det += "1"
                 else:
                     ref_det += "0"
-                if i < self.num_active_elec_beta: 
+                if i < self.num_active_elec_beta:
                     ref_det += "1"
                 else:
                     ref_det += "0"
         # Construct spin orbital indices
         self.inactive_spin_idx = [x for x in range(self.num_inactive_spin_orbs)]
         self.active_spin_idx = [x + self.num_inactive_spin_orbs for x in range(self.num_active_spin_orbs)]
-        self.virtual_spin_idx = [x + self.num_inactive_spin_orbs + self.num_active_spin_orbs for x in range(self.num_virtual_spin_orbs)]
+        self.virtual_spin_idx = [
+            x + self.num_inactive_spin_orbs + self.num_active_spin_orbs
+            for x in range(self.num_virtual_spin_orbs)
+        ]
         self.active_occ_spin_idx = []
         self.active_unocc_spin_idx = []
         for i, orb_idx in enumerate(self.active_spin_idx):
@@ -209,28 +234,33 @@ class WaveFunctionUPS:
                 self.active_unocc_spin_idx.append(orb_idx)
         self.active_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_spin_idx]
         self.active_occ_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_occ_spin_idx]
-        self.active_unocc_spin_idx_shifted = [x - self.num_inactive_spin_orbs for x in self.active_unocc_spin_idx]
+        self.active_unocc_spin_idx_shifted = [
+            x - self.num_inactive_spin_orbs for x in self.active_unocc_spin_idx
+        ]
         # Construct spatial idx
         self.inactive_idx = [x for x in range(self.num_inactive_orbs)]
         self.active_idx = [x + self.num_inactive_orbs for x in range(self.num_active_orbs)]
-        self.virtual_idx = [x + self.num_inactive_orbs + self.num_active_orbs for x in range(self.num_virtual_orbs)]
+        self.virtual_idx = [
+            x + self.num_inactive_orbs + self.num_active_orbs for x in range(self.num_virtual_orbs)
+        ]
         self.active_occ_idx = []
         self.active_unocc_idx = []
         for i, orb_idx in enumerate(self.active_idx):
-            if ref_det[2*i] == "1" and ref_det[2*i+1] == "1":
+            if ref_det[2 * i] == "1" and ref_det[2 * i + 1] == "1":
                 self.active_occ_idx.append(orb_idx)
-            elif ref_det[2*i] == "0" and ref_det[2*i+1] == "0":
+            elif ref_det[2 * i] == "0" and ref_det[2 * i + 1] == "0":
+                self.active_unocc_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "both":
+                self.active_occ_idx.append(orb_idx)
+                self.active_unocc_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
+                self.active_occ_idx.append(orb_idx)
+            elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
                 self.active_unocc_idx.append(orb_idx)
             else:
-                if self.wavefunction_options["resolve_unpaired_idx"] == "both":
-                    self.active_occ_idx.append(orb_idx)
-                    self.active_unocc_idx.append(orb_idx)
-                elif self.wavefunction_options["resolve_unpaired_idx"] == "occ":
-                    self.active_occ_idx.append(orb_idx)
-                elif self.wavefunction_options["resolve_unpaired_idx"] == "unocc":
-                    self.active_unocc_idx.append(orb_idx)
-                else:
-                    raise ValueError(f"Got unknown option for resolve_unpaired_idx, {ansatz_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'.")
+                raise ValueError(
+                    f"Got unknown option for resolve_unpaired_idx, {ansatz_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'."
+                )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
         self.active_unocc_idx_shifted = [x - self.num_inactive_orbs for x in self.active_unocc_idx]
@@ -239,7 +269,6 @@ class WaveFunctionUPS:
         kappa_idx = []
         kappa_no_activeactive_idx = []
         kappa_no_activeactive_idx_dagger = []
-        kappa_redundant_idx = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
         # Loop over all q>p orb combinations and find redundant kappas
@@ -247,14 +276,11 @@ class WaveFunctionUPS:
             for q in range(p + 1, self.num_orbs):
                 # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:
-                    kappa_redundant_idx.append((p, q))
                     continue
                 if not self._include_active_kappa:
                     if p in self.active_idx and q in self.active_idx:
-                        kappa_redundant_idx.append((p, q))
                         continue
                 if not (p in self.active_idx and q in self.active_idx):
                     kappa_no_activeactive_idx.append((p, q))
@@ -276,7 +302,6 @@ class WaveFunctionUPS:
         self.kappa_idx = np.array(kappa_idx, dtype=int)
         self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
         self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
-        self.kappa_redundant_idx = np.array(kappa_redundant_idx, dtype=int)
         self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         # Construct determinant basis
         self.ci_info = get_indexing(
@@ -443,17 +468,17 @@ class WaveFunctionUPS:
         if self._rdm1 is None:
             self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs))
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     val = expectation_value(
                         self.ci_coeffs,
                         [Epq(p, q)],
                         self.ci_coeffs,
                         self.ci_info,
                     )
-                    self._rdm1[p_idx, q_idx] = val  # type: ignore
-                    self._rdm1[q_idx, p_idx] = val  # type: ignore
+                    self._rdm1[p_, q_] = val  # type: ignore
+                    self._rdm1[q_, p_] = val  # type: ignore
         return self._rdm1
 
     @property
@@ -473,11 +498,11 @@ class WaveFunctionUPS:
                 )
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         if p == q:
                             s_lim = r + 1
                         elif p == r:
@@ -487,7 +512,7 @@ class WaveFunctionUPS:
                         else:
                             s_lim = p + 1
                         for s in range(self.num_inactive_orbs, s_lim):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             val = expectation_value(
                                 self.ci_coeffs,
                                 [Epq(p, q) * Epq(r, s)],
@@ -495,11 +520,11 @@ class WaveFunctionUPS:
                                 self.ci_info,
                             )
                             if q == r:
-                                val -= self.rdm1[p_idx, s_idx]
-                            self._rdm2[p_idx, q_idx, r_idx, s_idx] = val  # type: ignore
-                            self._rdm2[r_idx, s_idx, p_idx, q_idx] = val  # type: ignore
-                            self._rdm2[q_idx, p_idx, s_idx, r_idx] = val  # type: ignore
-                            self._rdm2[s_idx, r_idx, q_idx, p_idx] = val  # type: ignore
+                                val -= self.rdm1[p_, s_]
+                            self._rdm2[p_, q_, r_, s_] = val  # type: ignore
+                            self._rdm2[r_, s_, p_, q_] = val  # type: ignore
+                            self._rdm2[q_, p_, s_, r_] = val  # type: ignore
+                            self._rdm2[s_, r_, q_, p_] = val  # type: ignore
         return self._rdm2
 
     @property
@@ -523,17 +548,17 @@ class WaveFunctionUPS:
                 )
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         for s in range(self.num_inactive_orbs, p + 1):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             for t in range(self.num_inactive_orbs, r + 1):
-                                t_idx = t - self.num_inactive_orbs
+                                t_ = t - self.num_inactive_orbs
                                 for u in range(self.num_inactive_orbs, p + 1):
-                                    u_idx = u - self.num_inactive_orbs
+                                    u_ = u - self.num_inactive_orbs
                                     val = expectation_value(
                                         self.ci_coeffs,
                                         [Epq(p, q), Epq(r, s), Epq(t, u)],
@@ -541,25 +566,25 @@ class WaveFunctionUPS:
                                         self.ci_info,
                                     )
                                     if t == s:
-                                        val -= self.rdm2[p_idx, q_idx, r_idx, u_idx]
+                                        val -= self.rdm2[p_, q_, r_, u_]
                                     if r == q:
-                                        val -= self.rdm2[p_idx, s_idx, t_idx, u_idx]
+                                        val -= self.rdm2[p_, s_, t_, u_]
                                     if t == q:
-                                        val -= self.rdm2[p_idx, u_idx, r_idx, s_idx]
+                                        val -= self.rdm2[p_, u_, r_, s_]
                                     if t == s and r == q:
-                                        val -= self.rdm1[p_idx, u_idx]
-                                    self._rdm3[p_idx, q_idx, r_idx, s_idx, t_idx, u_idx] = val  # type: ignore
-                                    self._rdm3[p_idx, q_idx, t_idx, u_idx, r_idx, s_idx] = val  # type: ignore
-                                    self._rdm3[r_idx, s_idx, p_idx, q_idx, t_idx, u_idx] = val  # type: ignore
-                                    self._rdm3[r_idx, s_idx, t_idx, u_idx, p_idx, q_idx] = val  # type: ignore
-                                    self._rdm3[t_idx, u_idx, p_idx, q_idx, r_idx, s_idx] = val  # type: ignore
-                                    self._rdm3[t_idx, u_idx, r_idx, s_idx, p_idx, q_idx] = val  # type: ignore
-                                    self._rdm3[q_idx, p_idx, s_idx, r_idx, u_idx, t_idx] = val  # type: ignore
-                                    self._rdm3[q_idx, p_idx, u_idx, t_idx, s_idx, r_idx] = val  # type: ignore
-                                    self._rdm3[s_idx, r_idx, q_idx, p_idx, u_idx, t_idx] = val  # type: ignore
-                                    self._rdm3[s_idx, r_idx, u_idx, t_idx, q_idx, p_idx] = val  # type: ignore
-                                    self._rdm3[u_idx, t_idx, q_idx, p_idx, s_idx, r_idx] = val  # type: ignore
-                                    self._rdm3[u_idx, t_idx, s_idx, r_idx, q_idx, p_idx] = val  # type: ignore
+                                        val -= self.rdm1[p_, u_]
+                                    self._rdm3[p_, q_, r_, s_, t_, u_] = val  # type: ignore
+                                    self._rdm3[p_, q_, t_, u_, r_, s_] = val  # type: ignore
+                                    self._rdm3[r_, s_, p_, q_, t_, u_] = val  # type: ignore
+                                    self._rdm3[r_, s_, t_, u_, p_, q_] = val  # type: ignore
+                                    self._rdm3[t_, u_, p_, q_, r_, s_] = val  # type: ignore
+                                    self._rdm3[t_, u_, r_, s_, p_, q_] = val  # type: ignore
+                                    self._rdm3[q_, p_, s_, r_, u_, t_] = val  # type: ignore
+                                    self._rdm3[q_, p_, u_, t_, s_, r_] = val  # type: ignore
+                                    self._rdm3[s_, r_, q_, p_, u_, t_] = val  # type: ignore
+                                    self._rdm3[s_, r_, u_, t_, q_, p_] = val  # type: ignore
+                                    self._rdm3[u_, t_, q_, p_, s_, r_] = val  # type: ignore
+                                    self._rdm3[u_, t_, s_, r_, q_, p_] = val  # type: ignore
         return self._rdm3
 
     @property
@@ -585,21 +610,21 @@ class WaveFunctionUPS:
                 )
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
-                p_idx = p - self.num_inactive_orbs
+                p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
-                    q_idx = q - self.num_inactive_orbs
+                    q_ = q - self.num_inactive_orbs
                     for r in range(self.num_inactive_orbs, p + 1):
-                        r_idx = r - self.num_inactive_orbs
+                        r_ = r - self.num_inactive_orbs
                         for s in range(self.num_inactive_orbs, p + 1):
-                            s_idx = s - self.num_inactive_orbs
+                            s_ = s - self.num_inactive_orbs
                             for t in range(self.num_inactive_orbs, r + 1):
-                                t_idx = t - self.num_inactive_orbs
+                                t_ = t - self.num_inactive_orbs
                                 for u in range(self.num_inactive_orbs, p + 1):
-                                    u_idx = u - self.num_inactive_orbs
+                                    u_ = u - self.num_inactive_orbs
                                     for m in range(self.num_inactive_orbs, t + 1):
-                                        m_idx = m - self.num_inactive_orbs
+                                        m_ = m - self.num_inactive_orbs
                                         for n in range(self.num_inactive_orbs, p + 1):
-                                            n_idx = n - self.num_inactive_orbs
+                                            n_ = n - self.num_inactive_orbs
                                             val = expectation_value(
                                                 self.ci_coeffs,
                                                 [Epq(p, q), Epq(r, s), Epq(t, u), Epq(m, n)],
@@ -607,177 +632,81 @@ class WaveFunctionUPS:
                                                 self.ci_info,
                                             )
                                             if r == q:
-                                                val -= self.rdm3[p_idx, s_idx, t_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, s_, t_, u_, m_, n_]
                                             if t == q:
-                                                val -= self.rdm3[p_idx, u_idx, r_idx, s_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, u_, r_, s_, m_, n_]
                                             if m == q:
-                                                val -= self.rdm3[p_idx, n_idx, r_idx, s_idx, t_idx, u_idx]
+                                                val -= self.rdm3[p_, n_, r_, s_, t_, u_]
                                             if m == u:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, s_idx, t_idx, n_idx]
+                                                val -= self.rdm3[p_, q_, r_, s_, t_, n_]
                                             if t == s:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm3[p_, q_, r_, u_, m_, n_]
                                             if m == s:
-                                                val -= self.rdm3[p_idx, q_idx, r_idx, n_idx, t_idx, u_idx]
+                                                val -= self.rdm3[p_, q_, r_, n_, t_, u_]
                                             if m == u and r == q:
-                                                val -= self.rdm2[p_idx, s_idx, t_idx, n_idx]
+                                                val -= self.rdm2[p_, s_, t_, n_]
                                             if m == u and t == q:
-                                                val -= self.rdm2[p_idx, n_idx, r_idx, s_idx]
+                                                val -= self.rdm2[p_, n_, r_, s_]
                                             if t == s and m == u:
-                                                val -= self.rdm2[p_idx, q_idx, r_idx, n_idx]
+                                                val -= self.rdm2[p_, q_, r_, n_]
                                             if t == s and r == q:
-                                                val -= self.rdm2[p_idx, u_idx, m_idx, n_idx]
+                                                val -= self.rdm2[p_, u_, m_, n_]
                                             if t == s and m == q:
-                                                val -= self.rdm2[p_idx, n_idx, r_idx, u_idx]
+                                                val -= self.rdm2[p_, n_, r_, u_]
                                             if m == s and r == q:
-                                                val -= self.rdm2[p_idx, n_idx, t_idx, u_idx]
+                                                val -= self.rdm2[p_, n_, t_, u_]
                                             if m == s and t == q:
-                                                val -= self.rdm2[p_idx, u_idx, r_idx, n_idx]
+                                                val -= self.rdm2[p_, u_, r_, n_]
                                             if m == u and t == s and r == q:
-                                                val -= self.rdm1[p_idx, n_idx]
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, r_idx, s_idx, t_idx, u_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, r_idx, s_idx, m_idx, n_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, t_idx, u_idx, r_idx, s_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, t_idx, u_idx, m_idx, n_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, m_idx, n_idx, r_idx, s_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                p_idx, q_idx, m_idx, n_idx, t_idx, u_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, p_idx, q_idx, t_idx, u_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, p_idx, q_idx, m_idx, n_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, t_idx, u_idx, p_idx, q_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, t_idx, u_idx, m_idx, n_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, m_idx, n_idx, p_idx, q_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                r_idx, s_idx, m_idx, n_idx, t_idx, u_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, p_idx, q_idx, r_idx, s_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, p_idx, q_idx, m_idx, n_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, r_idx, s_idx, p_idx, q_idx, m_idx, n_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, r_idx, s_idx, m_idx, n_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, m_idx, n_idx, p_idx, q_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                t_idx, u_idx, m_idx, n_idx, r_idx, s_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, p_idx, q_idx, r_idx, s_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, p_idx, q_idx, t_idx, u_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, r_idx, s_idx, p_idx, q_idx, t_idx, u_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, r_idx, s_idx, t_idx, u_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, t_idx, u_idx, p_idx, q_idx, r_idx, s_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                m_idx, n_idx, t_idx, u_idx, r_idx, s_idx, p_idx, q_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, s_idx, r_idx, u_idx, t_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, s_idx, r_idx, n_idx, m_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, u_idx, t_idx, s_idx, r_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, u_idx, t_idx, n_idx, m_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, n_idx, m_idx, s_idx, r_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                q_idx, p_idx, n_idx, m_idx, u_idx, t_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, q_idx, p_idx, u_idx, t_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, q_idx, p_idx, n_idx, m_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, u_idx, t_idx, q_idx, p_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, u_idx, t_idx, n_idx, m_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, n_idx, m_idx, q_idx, p_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                s_idx, r_idx, n_idx, m_idx, u_idx, t_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, q_idx, p_idx, s_idx, r_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, q_idx, p_idx, n_idx, m_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, s_idx, r_idx, q_idx, p_idx, n_idx, m_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, s_idx, r_idx, n_idx, m_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, n_idx, m_idx, q_idx, p_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                u_idx, t_idx, n_idx, m_idx, s_idx, r_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, q_idx, p_idx, s_idx, r_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, q_idx, p_idx, u_idx, t_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, s_idx, r_idx, q_idx, p_idx, u_idx, t_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, s_idx, r_idx, u_idx, t_idx, q_idx, p_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, u_idx, t_idx, q_idx, p_idx, s_idx, r_idx
-                                            ] = val
-                                            self._rdm4[  # type: ignore
-                                                n_idx, m_idx, u_idx, t_idx, s_idx, r_idx, q_idx, p_idx
-                                            ] = val
+                                                val -= self.rdm1[p_, n_]
+                                            self._rdm4[p_, q_, r_, s_, t_, u_, m_, n_] = val  # type: ignore
+                                            self._rdm4[p_, q_, r_, s_, m_, n_, t_, u_] = val  # type: ignore
+                                            self._rdm4[p_, q_, t_, u_, r_, s_, m_, n_] = val  # type: ignore
+                                            self._rdm4[p_, q_, t_, u_, m_, n_, r_, s_] = val  # type: ignore
+                                            self._rdm4[p_, q_, m_, n_, r_, s_, t_, u_] = val  # type: ignore
+                                            self._rdm4[p_, q_, m_, n_, t_, u_, r_, s_] = val  # type: ignore
+                                            self._rdm4[r_, s_, p_, q_, t_, u_, m_, n_] = val  # type: ignore
+                                            self._rdm4[r_, s_, p_, q_, m_, n_, t_, u_] = val  # type: ignore
+                                            self._rdm4[r_, s_, t_, u_, p_, q_, m_, n_] = val  # type: ignore
+                                            self._rdm4[r_, s_, t_, u_, m_, n_, p_, q_] = val  # type: ignore
+                                            self._rdm4[r_, s_, m_, n_, p_, q_, t_, u_] = val  # type: ignore
+                                            self._rdm4[r_, s_, m_, n_, t_, u_, p_, q_] = val  # type: ignore
+                                            self._rdm4[t_, u_, p_, q_, r_, s_, m_, n_] = val  # type: ignore
+                                            self._rdm4[t_, u_, p_, q_, m_, n_, r_, s_] = val  # type: ignore
+                                            self._rdm4[t_, u_, r_, s_, p_, q_, m_, n_] = val  # type: ignore
+                                            self._rdm4[t_, u_, r_, s_, m_, n_, p_, q_] = val  # type: ignore
+                                            self._rdm4[t_, u_, m_, n_, p_, q_, r_, s_] = val  # type: ignore
+                                            self._rdm4[t_, u_, m_, n_, r_, s_, p_, q_] = val  # type: ignore
+                                            self._rdm4[m_, n_, p_, q_, r_, s_, t_, u_] = val  # type: ignore
+                                            self._rdm4[m_, n_, p_, q_, t_, u_, r_, s_] = val  # type: ignore
+                                            self._rdm4[m_, n_, r_, s_, p_, q_, t_, u_] = val  # type: ignore
+                                            self._rdm4[m_, n_, r_, s_, t_, u_, p_, q_] = val  # type: ignore
+                                            self._rdm4[m_, n_, t_, u_, p_, q_, r_, s_] = val  # type: ignore
+                                            self._rdm4[m_, n_, t_, u_, r_, s_, p_, q_] = val  # type: ignore
+                                            self._rdm4[q_, p_, s_, r_, u_, t_, n_, m_] = val  # type: ignore
+                                            self._rdm4[q_, p_, s_, r_, n_, m_, u_, t_] = val  # type: ignore
+                                            self._rdm4[q_, p_, u_, t_, s_, r_, n_, m_] = val  # type: ignore
+                                            self._rdm4[q_, p_, u_, t_, n_, m_, s_, r_] = val  # type: ignore
+                                            self._rdm4[q_, p_, n_, m_, s_, r_, u_, t_] = val  # type: ignore
+                                            self._rdm4[q_, p_, n_, m_, u_, t_, s_, r_] = val  # type: ignore
+                                            self._rdm4[s_, r_, q_, p_, u_, t_, n_, m_] = val  # type: ignore
+                                            self._rdm4[s_, r_, q_, p_, n_, m_, u_, t_] = val  # type: ignore
+                                            self._rdm4[s_, r_, u_, t_, q_, p_, n_, m_] = val  # type: ignore
+                                            self._rdm4[s_, r_, u_, t_, n_, m_, q_, p_] = val  # type: ignore
+                                            self._rdm4[s_, r_, n_, m_, q_, p_, u_, t_] = val  # type: ignore
+                                            self._rdm4[s_, r_, n_, m_, u_, t_, q_, p_] = val  # type: ignore
+                                            self._rdm4[u_, t_, q_, p_, s_, r_, n_, m_] = val  # type: ignore
+                                            self._rdm4[u_, t_, q_, p_, n_, m_, s_, r_] = val  # type: ignore
+                                            self._rdm4[u_, t_, s_, r_, q_, p_, n_, m_] = val  # type: ignore
+                                            self._rdm4[u_, t_, s_, r_, n_, m_, q_, p_] = val  # type: ignore
+                                            self._rdm4[u_, t_, n_, m_, q_, p_, s_, r_] = val  # type: ignore
+                                            self._rdm4[u_, t_, n_, m_, s_, r_, q_, p_] = val  # type: ignore
+                                            self._rdm4[n_, m_, q_, p_, s_, r_, u_, t_] = val  # type: ignore
+                                            self._rdm4[n_, m_, q_, p_, u_, t_, s_, r_] = val  # type: ignore
+                                            self._rdm4[n_, m_, s_, r_, q_, p_, u_, t_] = val  # type: ignore
+                                            self._rdm4[n_, m_, s_, r_, u_, t_, q_, p_] = val  # type: ignore
+                                            self._rdm4[n_, m_, u_, t_, q_, p_, s_, r_] = val  # type: ignore
+                                            self._rdm4[n_, m_, u_, t_, s_, r_, q_, p_] = val  # type: ignore
         return self._rdm4
 
     def check_orthonormality(self, overlap_integral: np.ndarray) -> None:

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -311,6 +311,7 @@ class WaveFunctionUPS:
         self.ci_coeffs = np.copy(self.ref_coeffs)
         # Construct UPS Structure
         self.ups_layout = UpsStructure()
+        self.ansatz_options.setdefault("excitations", [])
         if ansatz.lower() in ("tups", "qnp"):
             if ansatz.lower() == "tups":
                 self.ansatz_options["do_tups"] = True
@@ -319,16 +320,16 @@ class WaveFunctionUPS:
             self.ups_layout.create_tiled(self.num_active_orbs, self.ansatz_options)
         elif ansatz.lower() in ("fucc", "fuccsd", "ksafupccgsd", "fuccpd", "safuccsd"):
             if ansatz.lower() == "fuccsd":
-                self.ansatz_options["S"] = True
-                self.ansatz_options["D"] = True
+                self.ansatz_options["excitations"].append("S")
+                self.ansatz_options["excitations"].append("D")
             elif ansatz.lower() == "ksafupccgsd":
-                self.ansatz_options["SAGS"] = True
-                self.ansatz_options["GpD"] = True
-            elif ansatz.lower() == "fuccspd":
-                self.ansatz_options["pD"] = True
+                self.ansatz_options["excitations"].append("SAGS")
+                self.ansatz_options["excitations"].append("GpD")
+            elif ansatz.lower() == "fuccpd":
+                self.ansatz_options["excitations"].append("pD")
             elif ansatz.lower() == "safuccspd":
-                self.ansatz_options["SAS"] = True
-                self.ansatz_options["SAD"] = True
+                self.ansatz_options["excitations"].append("SAS")
+                self.ansatz_options["excitations"].append("SAD")
             # Default options
             self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_fUCC(
@@ -341,9 +342,9 @@ class WaveFunctionUPS:
             )
         elif ansatz.lower() in ("sdsfuccsd", "ksasdsfupccgsd"):
             if ansatz.lower() == "sdsfuccsd":
-                self.ansatz_options["D"] = True
+                self.ansatz_options["excitations"].append("D")
             elif ansatz.lower() == "ksasdsfupccgsd":
-                self.ansatz_options["GpD"] = True
+                self.ansatz_options["excitations"].append("GpD")
             # Default options
             self.ansatz_options.setdefault("n_layers", 1)
             self.ups_layout.create_SDSfUCC(

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -97,7 +97,7 @@ class WaveFunctionUPS:
             if active_space[0] % 2 == 0:
                 cas = ((active_space[0] // 2, active_space[0] // 2), active_space[1])
             else:
-                # Uneven number of electrons mean one electron must be unpaired.
+                # Odd number of electrons mean one electron must be unpaired.
                 cas = ((active_space[0] // 2 + 1, active_space[0] // 2), active_space[1])
         else:
             cas = ((active_space[0][0], active_space[0][1]), active_space[1])
@@ -181,7 +181,6 @@ class WaveFunctionUPS:
             # Note self._c_mo is set previously but overwritten here.
             self._c_mo = pp_mo_coeffs
 
-            # Assign weight to reference
             ref_det = pp_det
         elif "reference_determinant" in self.wavefunction_options.keys():
             ref_det = self.wavefunction_options["reference_determinant"]
@@ -264,10 +263,9 @@ class WaveFunctionUPS:
         kappa_no_activeactive_idx_dagger = []
         self._kappa_old = []
         # kappa can be optimized in spatial basis
-        # Loop over all q>p orb combinations and find redundant kappas
+        # Loop over all q>p orb combinations.
         for p in range(0, self.num_orbs):
             for q in range(p + 1, self.num_orbs):
-                # find redundant kappas
                 if p in self.inactive_idx and q in self.inactive_idx:
                     continue
                 if p in self.virtual_idx and q in self.virtual_idx:

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -259,7 +259,7 @@ class WaveFunctionUPS:
                 self.active_unocc_idx.append(orb_idx)
             else:
                 raise ValueError(
-                    f"Got unknown option for resolve_unpaired_idx, {ansatz_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'."
+                    f"Got unknown option for resolve_unpaired_idx, {wavefunction_options['resolve_unpaired_idx']}, excepted 'both', 'occ' or 'unocc'."
                 )
         self.active_idx_shifted = [x - self.num_inactive_orbs for x in self.active_idx]
         self.active_occ_idx_shifted = [x - self.num_inactive_orbs for x in self.active_occ_idx]
@@ -466,7 +466,7 @@ class WaveFunctionUPS:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs))
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -495,7 +495,8 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -545,7 +546,8 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -607,7 +609,8 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                     self.num_active_orbs,
-                )
+                ),
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -709,16 +712,13 @@ class WaveFunctionUPS:
                                             self._rdm4[n_, m_, u_, t_, s_, r_, q_, p_] = val  # type: ignore
         return self._rdm4
 
-    def check_orthonormality(self, overlap_integral: np.ndarray) -> None:
+    def check_orthonormality(self) -> None:
         r"""Check orthonormality of orbitals.
 
         .. math::
             \boldsymbol{I} = \boldsymbol{C}_\text{MO}\boldsymbol{S}\boldsymbol{C}_\text{MO}^T
-
-        Args:
-            overlap_integral: Overlap integral in AO basis.
         """
-        S_ortho = one_electron_integral_transform(self.c_mo, overlap_integral)
+        S_ortho = one_electron_integral_transform(self.c_mo, self.int_gen.overlap)
         one = np.identity(len(S_ortho))
         diff = np.abs(S_ortho - one)
         print("Max ortho-normal diff:", np.max(diff))

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -91,7 +91,6 @@ class WaveFunctionUPS:
         self.num_inactive_orbs = self.num_inactive_spin_orbs // 2
         self.num_active_orbs = cas[1]
         self.num_active_spin_orbs = 2 * self.num_active_orbs
-        self.num_active_orbs = self.num_active_spin_orbs // 2
         self.num_virtual_orbs = (
             len(self.int_gen.kinetic_energy) - self.num_inactive_orbs - self.num_active_orbs
         )

--- a/slowquant/unitary_coupled_cluster/ups_wavefunction.py
+++ b/slowquant/unitary_coupled_cluster/ups_wavefunction.py
@@ -290,10 +290,10 @@ class WaveFunctionUPS:
                     kappa_hf_like_idx.append((p, q))
                 elif p in self.active_occ_idx and q in self.virtual_idx:
                     kappa_hf_like_idx.append((p, q))
-        self.kappa_idx = np.array(kappa_idx, dtype=np.int64)
-        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=np.int64)
-        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=np.int64)
-        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=np.int64)
+        self.kappa_idx = np.array(kappa_idx, dtype=int)
+        self.kappa_no_activeactive_idx = np.array(kappa_no_activeactive_idx, dtype=int)
+        self.kappa_no_activeactive_idx_dagger = np.array(kappa_no_activeactive_idx_dagger, dtype=int)
+        self.kappa_hf_like_idx = np.array(kappa_hf_like_idx, dtype=int)
         # Construct determinant basis
         self.ci_info = get_indexing(
             self.num_inactive_orbs,
@@ -303,13 +303,12 @@ class WaveFunctionUPS:
             self.num_active_elec_beta,
         )
         self.num_det = len(self.ci_info.idx2det)
-        self.ref_coeffs = np.zeros(self.num_det, dtype=np.float64)
+        self.ref_coeffs = np.zeros(self.num_det, dtype=float)
         print("Reference (active) determinant:", ref_det)
         self.ref_coeffs[self.ci_info.det2idx[int(ref_det, 2)]] = 1
         self.ci_coeffs = np.copy(self.ref_coeffs)
         # Construct UPS Structure
         self.ups_layout = UpsStructure()
-        self.ansatz_options.setdefault("excitations", [])
         if ansatz.lower() in ("tups", "qnp"):
             if ansatz.lower() == "tups":
                 self.ansatz_options["do_tups"] = True
@@ -317,6 +316,7 @@ class WaveFunctionUPS:
                 self.ansatz_options["do_qnp"] = True
             self.ups_layout.create_tiled(self.num_active_orbs, self.ansatz_options)
         elif ansatz.lower() in ("fucc", "fuccsd", "ksafupccgsd", "fuccpd", "safuccsd"):
+            self.ansatz_options.setdefault("excitations", [])
             if ansatz.lower() == "fuccsd":
                 self.ansatz_options["excitations"].append("S")
                 self.ansatz_options["excitations"].append("D")
@@ -339,6 +339,7 @@ class WaveFunctionUPS:
                 self.ansatz_options,
             )
         elif ansatz.lower() in ("sdsfuccsd", "ksasdsfupccgsd"):
+            self.ansatz_options.setdefault("excitations", [])
             if ansatz.lower() == "sdsfuccsd":
                 self.ansatz_options["excitations"].append("D")
             elif ansatz.lower() == "ksasdsfupccgsd":
@@ -461,7 +462,7 @@ class WaveFunctionUPS:
             One-electron reduced density matrix.
         """
         if self._rdm1 is None:
-            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=np.float64)
+            self._rdm1 = np.zeros((self.num_active_orbs, self.num_active_orbs), dtype=float)
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
                 for q in range(self.num_inactive_orbs, p + 1):
@@ -491,7 +492,7 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -542,7 +543,7 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -605,7 +606,7 @@ class WaveFunctionUPS:
                     self.num_active_orbs,
                     self.num_active_orbs,
                 ),
-                dtype=np.float64,
+                dtype=float,
             )
             for p in range(self.num_inactive_orbs, self.num_inactive_orbs + self.num_active_orbs):
                 p_ = p - self.num_inactive_orbs
@@ -819,7 +820,7 @@ class WaveFunctionUPS:
             and "1step_optimizer" not in self._optimization_options.keys()
         ):
             print(
-                "'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
+                f"'1step_optimizer' was not specifed using the optimizer specified as 'theta_optimizer': {self._optimization_options['theta_optimizer']}"
             )
             self._optimization_options["1step_optimizer"] = self._optimization_options["theta_optimizer"]
         print("### Parameters information:")
@@ -830,7 +831,7 @@ class WaveFunctionUPS:
         if self._optimization_options["opt_type"].lower() == "1step":
             self._run_wf_optimization_1step()
         elif self._optimization_options["opt_type"].lower() == "2step":
-            self._run_wf_optimization_1step()
+            self._run_wf_optimization_2step()
         else:
             raise ValueError(
                 f"Got unknown 'opt_type', {[self._optimization_options['opt_type']]} excpected '1step' or '2step'."

--- a/slowquant/unitary_coupled_cluster/util.py
+++ b/slowquant/unitary_coupled_cluster/util.py
@@ -573,6 +573,27 @@ class UccStructure:
             num_orbs: Number of spatial orbitals.
         """
         excitations = [x.lower() for x in excitations]
+        valid_excitations = (
+            "s",
+            "gs",
+            "sas",
+            "sags",
+            "d",
+            "gd",
+            "pd",
+            "gpd",
+            "t",
+            "q",
+            "5",
+            "6",
+            "sad",
+            "sagd",
+        )
+        for excitation in excitations:
+            if excitation not in valid_excitations:
+                raise ValueError(
+                    f"Got unknown excitation, {excitation}. Valid excitations are: {valid_excitations}"
+                )
         if "s" in excitations:
             for a, i in iterate_t1(occ_spin_idx, unocc_spin_idx):
                 self.excitation_operator_type.append("single")
@@ -664,8 +685,12 @@ class UpsStructure:
 
         Ansatz Options:
             * n_layers [int]: Number of layers.
-            * do_qnp [bool]: Do QNP tiling. (default: False)
-            * skip_last_singles [bool]: Skip last layer of singles operators. (default: False)
+            * do_tups [bool]: Do tUPS tiling.
+                             (default: False)
+            * do_qnp [bool]: Do QNP tiling.
+                             (default: False)
+            * skip_last_singles [bool]: Skip last layer of singles operators.
+                                        (default: False)
 
         Args:
             num_active_orbs: Number of spatial active orbitals.
@@ -764,17 +789,20 @@ class UpsStructure:
         #. 10.1021/acs.jctc.8b01004 (k-UpCCGSD)
 
         Ansatz Options:
+            excitations [list[str]]: List of fermionic excitations to include.
             * n_layers [int]: Number of layers.
-            * S [bool]: Add single excitations.
-            * GS [bool]: Add generalized single excitations.
-            * SAS [bool]: Add spin-adapted single excitations.
-            * SAGS [bool]: Add generalized spin-adapted single excitations.
-            * D [bool]: Add double excitations.
-            * GD [bool]: Add generalized double excitations.
-            * pD [bool]: Add pair double excitations.
-            * GpD [bool]: Add generalized pair double excitations.
-            * SAD [bool]: Add spin-adapted doubles.
-            * SAGD [bool]: Add generalized spin-adapted doubles.
+
+        Possible excitations:
+            * S: Add single excitations.
+            * GS: Add generalized single excitations.
+            * SAS: Add spin-adapted single excitations.
+            * SAGS: Add generalized spin-adapted single excitations.
+            * D: Add double excitations.
+            * GD: Add generalized double excitations.
+            * pD: Add pair double excitations.
+            * GpD: Add generalized pair double excitations.
+            * SAD: Add spin-adapted doubles.
+            * SAGD: Add generalized spin-adapted doubles.
 
         Args:
             occ_idx: Strongly occupied spatial orbital indices.
@@ -788,175 +816,124 @@ class UpsStructure:
             Factorized UCC ansatz.
         """
         # Options
-        valid_options = (
-            "n_layers",
-            "S",
-            "D",
-            "SAGS",
-            "pD",
-            "GpD",
-            "SAS",
-            "T",
-            "Q",
-            "5",
-            "6",
-            "SAD",
-            "GS",
-            "GD",
-            "SAGD",
-        )
+        valid_options = ("n_layers", "excitations")
         for option in ansatz_options:
             if option not in valid_options:
                 raise ValueError(f"Got unknown option for fUCC, {option}. Valid options are: {valid_options}")
         if "n_layers" not in ansatz_options.keys():
             raise ValueError("fUCC require the option 'n_layers'")
-        do_S = False
-        do_GS = False
-        do_SAS = False
-        do_SAGS = False
-        do_D = False
-        do_GD = False
-        do_pD = False
-        do_GpD = False
-        do_T = False
-        do_Q = False
-        do_5 = False
-        do_6 = False
-        do_SAD = False
-        do_SAGD = False
-        if "S" in ansatz_options.keys():
-            do_S = ansatz_options["S"]
-        if "GS" in ansatz_options.keys():
-            do_GS = ansatz_options["GS"]
-        if "SAS" in ansatz_options.keys():
-            do_SAS = ansatz_options["SAS"]
-        if "SAGS" in ansatz_options.keys():
-            do_SAGS = ansatz_options["SAGS"]
-        if "D" in ansatz_options.keys():
-            do_D = ansatz_options["D"]
-        if "GD" in ansatz_options.keys():
-            do_GD = ansatz_options["GD"]
-        if "pD" in ansatz_options.keys():
-            do_pD = ansatz_options["pD"]
-        if "GpD" in ansatz_options.keys():
-            do_GpD = ansatz_options["GpD"]
-        if "T" in ansatz_options.keys():
-            do_T = ansatz_options["T"]
-        if "Q" in ansatz_options.keys():
-            do_Q = ansatz_options["Q"]
-        if "5" in ansatz_options.keys():
-            do_5 = ansatz_options["5"]
-        if "6" in ansatz_options.keys():
-            do_6 = ansatz_options["6"]
-        if "SAD" in ansatz_options.keys():
-            do_SAD = ansatz_options["SAD"]
-        if "SAGD" in ansatz_options.keys():
-            do_SAGD = ansatz_options["SAGD"]
-        if True not in (
-            do_S,
-            do_SAS,
-            do_SAGS,
-            do_D,
-            do_pD,
-            do_GpD,
-            do_T,
-            do_Q,
-            do_5,
-            do_6,
-            do_SAD,
-            do_GS,
-            do_GD,
-            do_SAGD,
-        ):
+        if len(ansatz_options["excitations"]) == 0:
             raise ValueError("fUCC requires some excitations got none.")
+        excitations = [x.lower() for x in ansatz_options["excitations"]]
+        valid_excitations = (
+            "s",
+            "gs",
+            "sas",
+            "sags",
+            "d",
+            "gd",
+            "pd",
+            "gpd",
+            "t",
+            "q",
+            "5",
+            "6",
+            "sad",
+            "sagd",
+        )
+        for excitation in excitations:
+            if excitation not in valid_excitations:
+                raise ValueError(
+                    f"Got unknown excitation, {excitation}. Valid excitations are: {valid_excitations}"
+                )
         n_layers = ansatz_options["n_layers"]
         # Layer loop
         for _ in range(n_layers):
-            if do_S:
+            if "s" in excitations:
                 for a, i in iterate_t1(occ_spin_idx, unocc_spin_idx):
                     self.excitation_operator_type.append("single")
                     self.excitation_indices.append((i, a))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_GS:
+            if "gs" in excitations:
                 for a, i in iterate_t1_generalized(2 * num_orbs):
                     self.excitation_operator_type.append("single")
                     self.excitation_indices.append((i, a))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_SAS:
+            if "sas" in excitations:
                 for a, i, _ in iterate_t1_sa(occ_idx, unocc_idx):
                     self.excitation_operator_type.append("sa_single")
                     self.excitation_indices.append((i, a))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 4
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_SAGS:
+            if "sags" in excitations:
                 for a, i, _ in iterate_t1_sa_generalized(num_orbs):
                     self.excitation_operator_type.append("sa_single")
                     self.excitation_indices.append((i, a))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 4
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_D:
+            if "d" in excitations:
                 for a, i, b, j in iterate_t2(occ_spin_idx, unocc_spin_idx):
                     self.excitation_operator_type.append("double")
                     self.excitation_indices.append((i, j, a, b))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_GD:
+            if "gd" in excitations:
                 for a, i, b, j in iterate_t2_generalized(2 * num_orbs):
                     self.excitation_operator_type.append("double")
                     self.excitation_indices.append((i, j, a, b))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_pD:
+            if "pd" in excitations:
                 for a, i, b, j in iterate_pair_t2(occ_idx, unocc_idx):
                     self.excitation_operator_type.append("double")
                     self.excitation_indices.append((i, j, a, b))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_GpD:
+            if "gpd" in excitations:
                 for a, i, b, j in iterate_pair_t2_generalized(num_orbs):
                     self.excitation_operator_type.append("double")
                     self.excitation_indices.append((i, j, a, b))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_T:
+            if "t" in excitations:
                 for a, i, b, j, c, k in iterate_t3(occ_spin_idx, unocc_spin_idx):
                     self.excitation_operator_type.append("triple")
                     self.excitation_indices.append((i, j, k, a, b, c))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_Q:
+            if "q" in excitations:
                 for a, i, b, j, c, k, d, l in iterate_t4(occ_spin_idx, unocc_spin_idx):
                     self.excitation_operator_type.append("quadruple")
                     self.excitation_indices.append((i, j, k, l, a, b, c, d))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_5:
+            if "5" in excitations:
                 for a, i, b, j, c, k, d, l, e, m in iterate_t5(occ_spin_idx, unocc_spin_idx):
                     self.excitation_operator_type.append("quintuple")
                     self.excitation_indices.append((i, j, k, l, m, a, b, c, d, e))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_6:
+            if "6" in excitations:
                 for a, i, b, j, c, k, d, l, e, m, f, n in iterate_t6(occ_spin_idx, unocc_spin_idx):
                     self.excitation_operator_type.append("sextuple")
                     self.excitation_indices.append((i, j, k, l, m, n, a, b, c, d, e, f))
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_SAD:
+            if "sad" in excitations:
                 for a, i, b, j, _, op_case in iterate_t2_sa(occ_idx, unocc_idx):
                     self.excitation_operator_type.append(f"sa_double_{op_case}")
                     self.excitation_indices.append((i, j, a, b))
@@ -964,7 +941,7 @@ class UpsStructure:
                     # self.grad_param_R[f"p{self.n_params:09d}"] = None
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_SAGD:
+            if "sagd" in excitations:
                 for a, i, b, j, _, op_case in iterate_t2_sa_generalized(num_orbs):
                     self.excitation_operator_type.append(f"sa_double_{op_case}")
                     self.excitation_indices.append((i, j, a, b))
@@ -995,10 +972,13 @@ class UpsStructure:
         #. 10.1021/acs.jctc.8b01004 (k-UpCCGSD)
 
         Ansatz Options:
+            excitations [list[str]]: List of fermionic excitations to include.
             * n_layers [int]: Number of layers.
-            * D [bool]: Add double excitations.
-            * pD [bool]: Add pair double excitations.
-            * GpD [bool]: Add generalized pair double excitations.
+
+        Possible excitations:
+            * D: Add double excitations.
+            * pD: Add pair double excitations.
+            * GpD: Add generalized pair double excitations.
 
         Args:
             occ_idx: Strongly occupied spatial orbital indices.
@@ -1012,7 +992,7 @@ class UpsStructure:
             SDS ordered fUCC ansatz.
         """
         # Options
-        valid_options = ("n_layers", "D", "pD", "GpD")
+        valid_options = ("n_layers", "excitations")
         for option in ansatz_options:
             if option not in valid_options:
                 raise ValueError(
@@ -1020,22 +1000,20 @@ class UpsStructure:
                 )
         if "n_layers" not in ansatz_options.keys():
             raise ValueError("SDSfUCC require the option 'n_layers'")
-        do_D = False
-        do_pD = False
-        do_GpD = False
-        if "D" in ansatz_options.keys():
-            do_D = ansatz_options["D"]
-        if "pD" in ansatz_options.keys():
-            do_pD = ansatz_options["pD"]
-        if "GpD" in ansatz_options.keys():
-            do_GpD = ansatz_options["GpD"]
-        if True not in (do_D, do_pD, do_GpD):
+        if len(ansatz_options["excitations"]) == 0:
             raise ValueError("SDSfUCC requires some excitations got none.")
+        excitations = [x.lower() for x in ansatz_options["excitations"]]
+        valid_excitations = ("d", "pd", "gpd")
+        for excitation in excitations:
+            if excitation not in valid_excitations:
+                raise ValueError(
+                    f"Got unknown excitation, {excitation}. Valid excitations are: {valid_excitations}"
+                )
         n_layers = ansatz_options["n_layers"]
         # Layer loop
         for _ in range(n_layers):
             # Kind of D excitation determines indices for complete SDS block
-            if do_D:
+            if "d" in excitations:
                 for a, i, b, j in iterate_t2(occ_spin_idx, unocc_spin_idx):
                     if i % 2 == a % 2:
                         self.excitation_indices.append((i, a))
@@ -1058,7 +1036,7 @@ class UpsStructure:
                     self.grad_param_R[f"p{self.n_params:09d}"] = 2
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_pD:
+            if "pd" in excitations:
                 for a, i, b, j in iterate_pair_t2(occ_idx, unocc_idx):
                     self.excitation_operator_type.append("double")
                     self.excitation_indices.append((i // 2, a // 2))
@@ -1075,7 +1053,7 @@ class UpsStructure:
                     self.grad_param_R[f"p{self.n_params:09d}"] = 4
                     self.param_names.append(f"p{self.n_params:09d}")
                     self.n_params += 1
-            if do_GpD:
+            if "gpd" in excitations:
                 for a, i, b, j in iterate_pair_t2_generalized(num_orbs):
                     self.excitation_operator_type.append("sa_single")
                     self.excitation_indices.append((i // 2, a // 2))

--- a/slowquant/unitary_coupled_cluster/util.py
+++ b/slowquant/unitary_coupled_cluster/util.py
@@ -553,90 +553,96 @@ class UccStructure:
         self.excitation_operator_type: list[str] = []
         self.n_params = 0
 
-    def add_sa_singles(self, active_occ_idx: Sequence[int], active_unocc_idx: Sequence[int]) -> None:
-        """Add spin-adapted singles.
-
-        Args:
-            active_occ_idx: Active strongly occupied spatial orbital indices.
-            active_unocc_idx: Active weakly occupied spatial orbital indices.
-        """
-        for a, i, _ in iterate_t1_sa(active_occ_idx, active_unocc_idx):
-            self.excitation_indices.append((i, a))
-            self.excitation_operator_type.append("sa_single")
-            self.n_params += 1
-
-    def add_sa_doubles(self, active_occ_idx: Sequence[int], active_unocc_idx: Sequence[int]) -> None:
-        """Add spin-adapted doubles.
-
-        Args:
-            active_occ_idx: Active strongly occupied spatial orbital indices.
-            active_unocc_idx: Active weakly occupied spatial orbital indices.
-        """
-        for a, i, b, j, _, op_type in iterate_t2_sa(active_occ_idx, active_unocc_idx):
-            self.excitation_indices.append((i, j, a, b))
-            if op_type == 1:
-                self.excitation_operator_type.append("sa_double_1")
-            elif op_type == 2:
-                self.excitation_operator_type.append("sa_double_2")
-            elif op_type == 3:
-                self.excitation_operator_type.append("sa_double_3")
-            elif op_type == 4:
-                self.excitation_operator_type.append("sa_double_4")
-            elif op_type == 5:
-                self.excitation_operator_type.append("sa_double_5")
-            self.n_params += 1
-
-    def add_triples(self, active_occ_spin_idx: Sequence[int], active_unocc_spin_idx: Sequence[int]) -> None:
-        """Add alpha-number and beta-number conserving triples.
-
-        Args:
-            active_occ_spin_idx: Active strongly occupied spin orbital indices.
-            active_unocc_spin_idx: Active weakly occupied spin orbital indices.
-        """
-        for a, i, b, j, c, k in iterate_t3(active_occ_spin_idx, active_unocc_spin_idx):
-            self.excitation_indices.append((i, j, k, a, b, c))
-            self.excitation_operator_type.append("triple")
-            self.n_params += 1
-
-    def add_quadruples(
-        self, active_occ_spin_idx: Sequence[int], active_unocc_spin_idx: Sequence[int]
+    def add_excitations(
+        self,
+        excitations: list[str],
+        occ_idx: list[int],
+        unocc_idx: list[int],
+        occ_spin_idx: list[int],
+        unocc_spin_idx: list[int],
+        num_orbs: int,
     ) -> None:
-        """Add alpha-number and beta-number conserving quadruples.
+        """Add fermionic excitations.
 
         Args:
-            active_occ_spin_idx: Active strongly occupied spin orbital indices.
-            active_unocc_spin_idx: Active weakly occupied spin orbital indices.
+            excitations: List of fermionic excitations to include.
+            occ_idx: Strongly occupied spatial orbital indices.
+            unocc_idx: Weakly occupied spatial orbital indices.
+            occ_spin_idx: Stongly occupied spin orbital indices.
+            unocc_spin_idx: Weakly occupied spin orbital indices.
+            num_orbs: Number of spatial orbitals.
         """
-        for a, i, b, j, c, k, d, l in iterate_t4(active_occ_spin_idx, active_unocc_spin_idx):
-            self.excitation_indices.append((i, j, k, l, a, b, c, d))
-            self.excitation_operator_type.append("quadruple")
-            self.n_params += 1
-
-    def add_quintuples(
-        self, active_occ_spin_idx: Sequence[int], active_unocc_spin_idx: Sequence[int]
-    ) -> None:
-        """Add alpha-number and beta-number conserving quintuples.
-
-        Args:
-            active_occ_spin_idx: Active strongly occupied spin orbital indices.
-            active_unocc_spin_idx: Active weakly occupied spin orbital indices.
-        """
-        for a, i, b, j, c, k, d, l, e, m in iterate_t5(active_occ_spin_idx, active_unocc_spin_idx):
-            self.excitation_indices.append((i, j, k, l, m, a, b, c, d, e))
-            self.excitation_operator_type.append("quintuple")
-            self.n_params += 1
-
-    def add_sextuples(self, active_occ_spin_idx: Sequence[int], active_unocc_spin_idx: Sequence[int]) -> None:
-        """Add alpha-number and beta-number conserving sextuples.
-
-        Args:
-            active_occ_spin_idx: Active strongly occupied spin orbital indices.
-            active_unocc_spin_idx: Active weakly occupied spin orbital indices.
-        """
-        for a, i, b, j, c, k, d, l, e, m, f, n in iterate_t6(active_occ_spin_idx, active_unocc_spin_idx):
-            self.excitation_indices.append((i, j, k, l, m, n, a, b, c, d, e, f))
-            self.excitation_operator_type.append("sextuple")
-            self.n_params += 1
+        excitations = [x.lower() for x in excitations]
+        if "s" in excitations:
+            for a, i in iterate_t1(occ_spin_idx, unocc_spin_idx):
+                self.excitation_operator_type.append("single")
+                self.excitation_indices.append((i, a))
+                self.n_params += 1
+        if "gs" in excitations:
+            for a, i in iterate_t1_generalized(2 * num_orbs):
+                self.excitation_operator_type.append("single")
+                self.excitation_indices.append((i, a))
+                self.n_params += 1
+        if "sas" in excitations:
+            for a, i, _ in iterate_t1_sa(occ_idx, unocc_idx):
+                self.excitation_operator_type.append("sa_single")
+                self.excitation_indices.append((i, a))
+                self.n_params += 1
+        if "sags" in excitations:
+            for a, i, _ in iterate_t1_sa_generalized(num_orbs):
+                self.excitation_operator_type.append("sa_single")
+                self.excitation_indices.append((i, a))
+                self.n_params += 1
+        if "d" in excitations:
+            for a, i, b, j in iterate_t2(occ_spin_idx, unocc_spin_idx):
+                self.excitation_operator_type.append("double")
+                self.excitation_indices.append((i, j, a, b))
+                self.n_params += 1
+        if "gd" in excitations:
+            for a, i, b, j in iterate_t2_generalized(2 * num_orbs):
+                self.excitation_operator_type.append("double")
+                self.excitation_indices.append((i, j, a, b))
+                self.n_params += 1
+        if "pd" in excitations:
+            for a, i, b, j in iterate_pair_t2(occ_idx, unocc_idx):
+                self.excitation_operator_type.append("double")
+                self.excitation_indices.append((i, j, a, b))
+                self.n_params += 1
+        if "gpd" in excitations:
+            for a, i, b, j in iterate_pair_t2_generalized(num_orbs):
+                self.excitation_operator_type.append("double")
+                self.excitation_indices.append((i, j, a, b))
+                self.n_params += 1
+        if "t" in excitations:
+            for a, i, b, j, c, k in iterate_t3(occ_spin_idx, unocc_spin_idx):
+                self.excitation_operator_type.append("triple")
+                self.excitation_indices.append((i, j, k, a, b, c))
+                self.n_params += 1
+        if "q" in excitations:
+            for a, i, b, j, c, k, d, l in iterate_t4(occ_spin_idx, unocc_spin_idx):
+                self.excitation_operator_type.append("quadruple")
+                self.excitation_indices.append((i, j, k, l, a, b, c, d))
+                self.n_params += 1
+        if "5" in excitations:
+            for a, i, b, j, c, k, d, l, e, m in iterate_t5(occ_spin_idx, unocc_spin_idx):
+                self.excitation_operator_type.append("quintuple")
+                self.excitation_indices.append((i, j, k, l, m, a, b, c, d, e))
+                self.n_params += 1
+        if "6" in excitations:
+            for a, i, b, j, c, k, d, l, e, m, f, n in iterate_t6(occ_spin_idx, unocc_spin_idx):
+                self.excitation_operator_type.append("sextuple")
+                self.excitation_indices.append((i, j, k, l, m, n, a, b, c, d, e, f))
+                self.n_params += 1
+        if "sad" in excitations:
+            for a, i, b, j, _, op_case in iterate_t2_sa(occ_idx, unocc_idx):
+                self.excitation_operator_type.append(f"sa_double_{op_case}")
+                self.excitation_indices.append((i, j, a, b))
+                self.n_params += 1
+        if "sagd" in excitations:
+            for a, i, b, j, _, op_case in iterate_t2_sa_generalized(num_orbs):
+                self.excitation_operator_type.append(f"sa_double_{op_case}")
+                self.excitation_indices.append((i, j, a, b))
+                self.n_params += 1
 
 
 class UpsStructure:
@@ -767,6 +773,8 @@ class UpsStructure:
             * GD [bool]: Add generalized double excitations.
             * pD [bool]: Add pair double excitations.
             * GpD [bool]: Add generalized pair double excitations.
+            * SAD [bool]: Add spin-adapted doubles.
+            * SAGD [bool]: Add generalized spin-adapted doubles.
 
         Args:
             occ_idx: Strongly occupied spatial orbital indices.
@@ -795,6 +803,7 @@ class UpsStructure:
             "SAD",
             "GS",
             "GD",
+            "SAGD",
         )
         for option in ansatz_options:
             if option not in valid_options:
@@ -814,6 +823,7 @@ class UpsStructure:
         do_5 = False
         do_6 = False
         do_SAD = False
+        do_SAGD = False
         if "S" in ansatz_options.keys():
             do_S = ansatz_options["S"]
         if "GS" in ansatz_options.keys():
@@ -840,6 +850,8 @@ class UpsStructure:
             do_6 = ansatz_options["6"]
         if "SAD" in ansatz_options.keys():
             do_SAD = ansatz_options["SAD"]
+        if "SAGD" in ansatz_options.keys():
+            do_SAGD = ansatz_options["SAGD"]
         if True not in (
             do_S,
             do_SAS,
@@ -854,6 +866,7 @@ class UpsStructure:
             do_SAD,
             do_GS,
             do_GD,
+            do_SAGD,
         ):
             raise ValueError("fUCC requires some excitations got none.")
         n_layers = ansatz_options["n_layers"]
@@ -945,6 +958,14 @@ class UpsStructure:
                     self.n_params += 1
             if do_SAD:
                 for a, i, b, j, _, op_case in iterate_t2_sa(occ_idx, unocc_idx):
+                    self.excitation_operator_type.append(f"sa_double_{op_case}")
+                    self.excitation_indices.append((i, j, a, b))
+                    # Rotosolve not implemented for SA doubles
+                    # self.grad_param_R[f"p{self.n_params:09d}"] = None
+                    self.param_names.append(f"p{self.n_params:09d}")
+                    self.n_params += 1
+            if do_SAGD:
+                for a, i, b, j, _, op_case in iterate_t2_sa_generalized(num_orbs):
                     self.excitation_operator_type.append(f"sa_double_{op_case}")
                     self.excitation_indices.append((i, j, a, b))
                     # Rotosolve not implemented for SA doubles

--- a/slowquant/unitary_coupled_cluster/util.py
+++ b/slowquant/unitary_coupled_cluster/util.py
@@ -669,7 +669,7 @@ class UpsStructure:
             tUPS ansatz.
         """
         # Options
-        valid_options = ("n_layers", "do_qnp", "skip_last_singles", "do_tups", "do_pp")
+        valid_options = ("n_layers", "do_qnp", "skip_last_singles", "do_tups")
         for option in ansatz_options:
             if option not in valid_options:
                 raise ValueError(f"Got unknown option for tUPS, {option}. Valid options are: {valid_options}")

--- a/tests/test_oscillator_strength.py
+++ b/tests/test_oscillator_strength.py
@@ -28,9 +28,10 @@ def test_H2_631g_naive():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Linear Response
     LR = naive.LinearResponse(WF, excitations="SD")
@@ -80,9 +81,10 @@ def test_LiH_sto3g_naive():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Linear Response
     LR = naive.LinearResponse(WF, excitations="SD")
@@ -146,9 +148,10 @@ def test_H2_631g_projLR():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Linear Response
     LR = projected.LinearResponse(WF, excitations="SD")
@@ -193,9 +196,10 @@ def test_LiH_sto3g_proj():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     LR = projected.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
@@ -252,9 +256,10 @@ def test_H2_631g_STLR():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Linear Response
     LR = statetransfer.LinearResponse(
@@ -301,9 +306,10 @@ def test_LiH_sto3g_st():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Linear Response
     LR = statetransfer.LinearResponse(
@@ -364,9 +370,10 @@ def test_H2_631g_allST():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Linear Response
     LR = allstatetransfer.LinearResponse(
@@ -409,9 +416,10 @@ def test_LiH_sto3g_allST():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Linear Response
     LR = allstatetransfer.LinearResponse(

--- a/tests/test_oscillator_strength.py
+++ b/tests/test_oscillator_strength.py
@@ -29,9 +29,9 @@ def test_H2_631g_naive():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Linear Response
     LR = naive.LinearResponse(WF, excitations="SD")
@@ -82,9 +82,9 @@ def test_LiH_sto3g_naive():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Linear Response
     LR = naive.LinearResponse(WF, excitations="SD")
@@ -149,9 +149,9 @@ def test_H2_631g_projLR():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Linear Response
     LR = projected.LinearResponse(WF, excitations="SD")
@@ -197,9 +197,9 @@ def test_LiH_sto3g_proj():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     LR = projected.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
@@ -257,9 +257,9 @@ def test_H2_631g_STLR():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Linear Response
     LR = statetransfer.LinearResponse(
@@ -307,9 +307,9 @@ def test_LiH_sto3g_st():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Linear Response
     LR = statetransfer.LinearResponse(
@@ -371,9 +371,9 @@ def test_H2_631g_allST():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Linear Response
     LR = allstatetransfer.LinearResponse(
@@ -417,9 +417,9 @@ def test_LiH_sto3g_allST():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Linear Response
     LR = allstatetransfer.LinearResponse(

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -54,10 +54,11 @@ def test_LiH_naive() -> None:
         rhf.mo_coeff,
         mol,
         excitations=["SAS", "SAD"],
+        include_active_kappa=False,
     )
 
     # Optimize WF
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Optimize WF with QSQ
     sampler = SamplerAer()
@@ -70,9 +71,10 @@ def test_LiH_naive() -> None:
         WF.c_mo,
         mol,
         QI,
+        include_active_kappa=False,
     )
 
-    qWF.run_wf_optimization(True, optimization_options={"opt_type": "2step", "theta_optimizer": "rotosolve"})
+    qWF.run_wf_optimization(orbital_optimization=True, opt_type="2step", theta_optimizer="rotosolve")
 
     # LR with SQ
     LR = naive.LinearResponse(WF, excitations="SD")
@@ -121,8 +123,9 @@ def test_LiH_projected() -> None:
         rhf.mo_coeff,
         mol,
         excitations=["SAS", "SAD"],
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # CircuitWF with QSQ
     sampler = SamplerAer()
@@ -136,8 +139,9 @@ def test_LiH_projected() -> None:
         WF.c_mo,
         mol,
         QI,
+        include_active_kappa=False,
     )
-    qWF.run_wf_optimization_2step("rotosolve", True)
+    qWF.run_wf_optimization(orbital_optimization=True, opt_type="2step", theta_optimizer="rotosolve")
 
     # LR with QSQ
     qLR = q_projected.quantumLR(qWF, "SD")
@@ -179,11 +183,12 @@ def test_LiH_allprojected() -> None:
         (2, 2),
         rhf.mo_coeff,
         mol,
-        "SD",
+        excitations=["SAS", "SAD"],
+        include_active_kappa=False,
     )
 
     # Optimize WF
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Optimize WF with QSQ
     sampler = SamplerAer()
@@ -197,9 +202,10 @@ def test_LiH_allprojected() -> None:
         WF.c_mo,
         mol,
         QI,
+        include_active_kappa=False,
     )
 
-    qWF.run_wf_optimization_2step("rotosolve", True)
+    qWF.run_wf_optimization(orbital_optimization=True, opt_type="2step", theta_optimizer="rotosolve")
 
     # LR with SQ
     LR = allprojected.LinearResponse(WF, excitations="SD")
@@ -247,11 +253,12 @@ def test_LiH_naive_sampler_ISA() -> None:
         (2, 2),
         rhf.mo_coeff,
         mol,
-        "SD",
+        excitations=["SAS", "SAD"],
+        include_active_kappa=False,
     )
 
     # Optimize WF
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Optimize WF with QSQ
     sampler = SamplerAer()
@@ -264,9 +271,10 @@ def test_LiH_naive_sampler_ISA() -> None:
         WF.c_mo,
         mol,
         QI,
+        include_active_kappa=False,
     )
 
-    qWF.run_wf_optimization_2step("rotosolve", True)
+    qWF.run_wf_optimization(orbital_optimization=True, opt_type="2step", theta_optimizer="rotosolve")
 
     # LR with QSQ
     qLR = q_naive.quantumLR(qWF, "SD")
@@ -308,11 +316,12 @@ def test_LiH_oscillator_strength() -> None:
         (2, 2),
         rhf.mo_coeff,
         mol,
-        "SD",
+        excitations=["SAS", "SAD"],
+        include_active_kappa=False,
     )
 
     # Optimize WF
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     # Optimize WF with QSQ
     sampler = SamplerAer()
@@ -325,9 +334,10 @@ def test_LiH_oscillator_strength() -> None:
         WF.c_mo,
         mol,
         QI,
+        include_active_kappa=False,
     )
 
-    qWF.run_wf_optimization_2step("rotosolve", True)
+    qWF.run_wf_optimization(orbital_optimization=True, opt_type="2step", theta_optimizer="rotosolve")
 
     # naive LR with QSQ
     qLR_naive = q_naive.quantumLR(qWF, "SD")
@@ -426,7 +436,7 @@ def test_gradient_optimizer_H2() -> None:
         QI,
     )
 
-    WF.run_wf_optimization_2step("BFGS", False)
+    WF.run_wf_optimization(orbital_optimization=False, one_step_optimizer="rotosolve")
     assert abs(WF.energy_elec - -1.8572750819575072) < 10**-6
 
 
@@ -536,7 +546,7 @@ def test_fUCC_h2o() -> None:
         QI,
     )
 
-    WF.run_wf_optimization_2step("RotoSolve", False)
+    WF.run_wf_optimization(orbital_optimization=False, one_step_optimizer="rotosolve")
     assert abs(WF.energy_elec - -83.96650295692562) < 10**-6
 
 
@@ -622,8 +632,11 @@ def test_custom() -> None:
         rhf.mo_coeff,
         mol,
         QI,
+        include_active_kappa=False,
     )
-    qWF.run_wf_optimization_2step("rotosolve", True, is_silent_subiterations=True)
+    qWF.run_wf_optimization(
+        orbital_optimization=True, theta_optimizer="rotosolve", opt_type="2step", is_silent_subiterations=True
+    )
     energy = qWF._calc_energy_elec()
 
     qc = qWF.QI.circuit.copy()
@@ -674,9 +687,10 @@ def test_H2_sampler_layout() -> None:
         rhf.mo_coeff,
         mol,
         QI,
+        include_active_kappa=False,
     )
 
-    qWF.run_wf_optimization_2step("rotosolve", True)
+    qWF.run_wf_optimization(orbital_optimization=True, theta_optimizer="rotosolve", opt_type="2step")
 
     QI.update_pass_manager({"backend": FakeTorino()})
 
@@ -706,7 +720,7 @@ def test_mitigation_nocm() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     sampler = SamplerAer(backend_options={"noise_model": noise_model})
     mapper = JordanWignerMapper()
@@ -770,7 +784,7 @@ def test_mitigation() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     sampler = SamplerAer(backend_options={"noise_model": noise_model})
     mapper = JordanWignerMapper()
@@ -845,7 +859,7 @@ def test_state_average_layout() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1},
     )
-    WF.run_wf_optimization_1step("BFGS")
+    WF.run_wf_optimization(orbital_optimization=False)
 
     sampler = SamplerAer()
     mapper = JordanWignerMapper()
@@ -910,7 +924,7 @@ def test_state_average_M() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1},
     )
-    WF.run_wf_optimization_1step("BFGS")
+    WF.run_wf_optimization(orbital_optimization=False)
 
     sampler = SamplerAer(backend_options={"noise_model": noise_model})
     mapper = JordanWignerMapper()
@@ -978,7 +992,7 @@ def test_state_average_Mplus() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1},
     )
-    WF.run_wf_optimization_1step("BFGS")
+    WF.run_wf_optimization(orbital_optimization=False)
 
     sampler = SamplerAer()
     mapper = JordanWignerMapper()
@@ -1060,7 +1074,7 @@ def test_no_saving() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1},
     )
-    WF.run_wf_optimization_1step("BFGS")
+    WF.run_wf_optimization(orbital_optimization=False)
 
     sampler = SamplerAer()
     mapper = JordanWignerMapper()
@@ -1122,7 +1136,7 @@ def test_variance_nocm() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     sampler = SamplerAer(backend_options={"noise_model": noise_model})
     mapper = JordanWignerMapper()
@@ -1174,7 +1188,7 @@ def test_variance() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     sampler = SamplerAer(backend_options={"noise_model": noise_model})
     mapper = JordanWignerMapper()
@@ -1220,7 +1234,7 @@ def test_upslayout_input() -> None:
         mol,
         "fUCCSD",
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(orbital_optimization=False)
     sampler = SamplerAer()
     mapper = ParityMapper(num_particles=(1, 1))
     QI = QuantumInterface(sampler, WF.ups_layout, mapper)

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -53,11 +53,11 @@ def test_LiH_naive() -> None:
         (2, 2),
         rhf.mo_coeff,
         mol,
-        "SD",
+        excitations=["SAS", "SAD"],
     )
 
     # Optimize WF
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # Optimize WF with QSQ
     sampler = SamplerAer()
@@ -72,7 +72,7 @@ def test_LiH_naive() -> None:
         QI,
     )
 
-    qWF.run_wf_optimization_2step("rotosolve", True)
+    qWF.run_wf_optimization(True, optimization_options={"opt_type": "2step", "theta_optimizer": "rotosolve"})
 
     # LR with SQ
     LR = naive.LinearResponse(WF, excitations="SD")
@@ -120,9 +120,9 @@ def test_LiH_projected() -> None:
         (2, 2),
         rhf.mo_coeff,
         mol,
-        "SD",
+        excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     # CircuitWF with QSQ
     sampler = SamplerAer()

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -705,7 +705,6 @@ def test_mitigation_nocm() -> None:
         SQobj,
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -770,7 +769,6 @@ def test_mitigation() -> None:
         SQobj,
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -1123,7 +1121,6 @@ def test_variance_nocm() -> None:
         SQobj,
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -1176,7 +1173,6 @@ def test_variance() -> None:
         SQobj,
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 

--- a/tests/test_qiskit_unitary_product_state.py
+++ b/tests/test_qiskit_unitary_product_state.py
@@ -35,7 +35,7 @@ def test_tups() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     assert abs(WF.energy_elec - -8.82891657651419) < 10**-8
 
@@ -75,16 +75,15 @@ def test_fucc() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         "fUCCSD",
-        ansatz_options={},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     assert abs(WF.energy_elec - -8.828916576513892) < 10**-8
 
     # Circuit based UPS wave function
     mapper = JordanWignerMapper()
     primitive = Sampler(run_options={"shots": None})
-    QI = QuantumInterface(primitive, "fUCCSD", mapper, ansatz_options={})
+    QI = QuantumInterface(primitive, "fUCCSD", mapper)
     qWF = WaveFunctionCircuit(
         (2, 2),
         WF.c_mo,
@@ -117,7 +116,7 @@ def test_ksafupccgsd() -> None:
         "kSAfUpCCGSD",
         ansatz_options={"n_layers": 1},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     assert abs(WF.energy_elec - -8.828916576543133) < 10**-8
 
@@ -155,16 +154,15 @@ def test_sdsfuccsd() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         "SDSfUCCSD",
-        ansatz_options={},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     assert abs(WF.energy_elec - -8.82891657653415) < 10**-8
 
     # Circuit based UPS wave function
     mapper = JordanWignerMapper()
     primitive = Sampler(run_options={"shots": None})
-    QI = QuantumInterface(primitive, "SDSfUCCSD", mapper, ansatz_options={})
+    QI = QuantumInterface(primitive, "SDSfUCCSD", mapper)
     qWF = WaveFunctionCircuit(
         (2, 2),
         WF.c_mo,
@@ -197,7 +195,7 @@ def test_ksasdsfupccgsd() -> None:
         "kSASDSfUpCCGSD",
         ansatz_options={"n_layers": 1},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     assert abs(WF.energy_elec - -8.828916576542285) < 10**-8
 
@@ -270,7 +268,7 @@ def test_lih_fucc_mappings() -> None:
         mol,
         "fUCCSD",
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - -8.82972563114591) < 10**-10
 
     sampler = Sampler()
@@ -314,7 +312,7 @@ def test_lih_sdsfucc_mappings() -> None:
         mol,
         "SDSfUCCSD",
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - -8.829725631105443) < 10**-10
 
     sampler = Sampler()
@@ -359,7 +357,7 @@ def test_lih_tups_mappings() -> None:
         "tUPS",
         ansatz_options={"n_layers": 4},
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - -8.825023029148799) < 10**-10
 
     sampler = Sampler()
@@ -406,7 +404,7 @@ def test_h2_selfconsistent_lr() -> None:
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
 
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     mapper = JordanWignerMapper()
     primitive = Sampler(run_options={"shots": None})
@@ -451,7 +449,7 @@ def test_h2_statetransfer_lr() -> None:
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
 
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     mapper = JordanWignerMapper()
     primitive = Sampler(run_options={"shots": None})
@@ -494,7 +492,7 @@ def test_convert_ups_to_circuit() -> None:
         SQobj,
         "fUCCSD",
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
     mapper = JordanWignerMapper()
     primitive = Sampler(run_options={"shots": None})
     qWF = circuit_wavefunction_from_ups(WF, primitive, mapper)
@@ -533,7 +531,7 @@ def test_convert_saups_to_circuit() -> None:
         "tUPS",
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
     )
-    WF.run_wf_optimization_2step("BFGS", True)
+    WF.run_wf_optimization(orbital_optimization=True)
     mapper = JordanWignerMapper()
     primitive = Sampler(run_options={"shots": None})
     qWF = circuit_wavefunction_from_ups(WF, primitive, mapper)
@@ -567,10 +565,10 @@ def test_pp_ups_to_circuit() -> None:
         integral_generator,
         "tUPS",  # our circuit Ansatz
         ansatz_options={"n_layers": 1, "skip_last_singles": True},  # we use 1 layer
-        wavefunction_options={"do_pp": True},
+        do_pp=True,
     )
 
-    WF.run_wf_optimization_1step("bfgs", orbital_optimization=True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     assert abs(WF.energy_elec + 83.98433373390003) < 10**-10
 

--- a/tests/test_qiskit_unitary_product_state.py
+++ b/tests/test_qiskit_unitary_product_state.py
@@ -34,7 +34,6 @@ def test_tups() -> None:
         SQobj,
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -77,7 +76,6 @@ def test_fucc() -> None:
         SQobj,
         "fUCCSD",
         ansatz_options={},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -118,7 +116,6 @@ def test_ksafupccgsd() -> None:
         SQobj,
         "kSAfUpCCGSD",
         ansatz_options={"n_layers": 1},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -159,7 +156,6 @@ def test_sdsfuccsd() -> None:
         SQobj,
         "SDSfUCCSD",
         ansatz_options={},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -200,7 +196,6 @@ def test_ksasdsfupccgsd() -> None:
         SQobj,
         "kSASDSfUpCCGSD",
         ansatz_options={"n_layers": 1},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
@@ -409,7 +404,6 @@ def test_h2_selfconsistent_lr() -> None:
         SQobj,
         ansatz="tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
 
     WF.run_wf_optimization_1step("BFGS", True)
@@ -455,7 +449,6 @@ def test_h2_statetransfer_lr() -> None:
         SQobj,
         ansatz="tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
 
     WF.run_wf_optimization_1step("BFGS", True)
@@ -500,7 +493,6 @@ def test_convert_ups_to_circuit() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         "fUCCSD",
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
     mapper = JordanWignerMapper()
@@ -540,7 +532,6 @@ def test_convert_saups_to_circuit() -> None:
         ),
         "tUPS",
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_2step("BFGS", True)
     mapper = JordanWignerMapper()
@@ -575,8 +566,8 @@ def test_pp_ups_to_circuit() -> None:
         mo_coeff,
         integral_generator,
         "tUPS",  # our circuit Ansatz
-        ansatz_options={"n_layers": 1, "do_pp": True, "skip_last_singles": True},  # we use 1 layer
-        include_active_kappa=True,
+        ansatz_options={"n_layers": 1, "skip_last_singles": True},  # we use 1 layer
+        wavefunction_options={"do_pp": True},
     )
 
     WF.run_wf_optimization_1step("bfgs", orbital_optimization=True)

--- a/tests/test_qiskit_unitary_product_state.py
+++ b/tests/test_qiskit_unitary_product_state.py
@@ -575,3 +575,28 @@ def test_pp_ups_to_circuit() -> None:
     qWF = circuit_wavefunction_from_ups(WF, Sampler(), JordanWignerMapper(), shots=None)
 
     assert abs(qWF.energy_elec + 83.9843337275081) < 10**-10
+
+
+def test_openshell_reference() -> None:
+    """Test circuit wavefunction for openshell reference."""
+    mol = pyscf.M(
+        atom="H   0.0 0.0 0.0; H   1.0 0.0 0.0; H   0.5 0.8660254038  0.0;",
+        basis="sto-3g",
+        unit="angstrom",
+        spin=1,
+    )
+    rohf = pyscf.scf.ROHF(mol).run()
+
+    WF = WaveFunctionUPS(
+        (3, 3),
+        rohf.mo_coeff,
+        mol,
+        "fUCC",
+        ansatz_options={"excitations": ["S", "D"]},
+        reference_determinant="111000",
+    )
+    WF.run_wf_optimization(orbital_optimization=False)
+    mapper = JordanWignerMapper()
+    primitive = Sampler(run_options={"shots": None})
+    qWF = circuit_wavefunction_from_ups(WF, primitive, mapper)
+    assert abs(WF.energy_elec - qWF.energy_elec) < 10**-10

--- a/tests/test_unitary_coupled_cluster.py
+++ b/tests/test_unitary_coupled_cluster.py
@@ -107,7 +107,6 @@ def test_h2_431g_oouccd() -> None:
         A.hartree_fock.mo_coeff,
         A,
         "D",
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
     assert abs(WF.energy_elec - (-1.860533598715)) < 10**-8
@@ -154,7 +153,6 @@ def test_h4_sto3g_oouccd() -> None:
         A.hartree_fock.mo_coeff,
         A,
         "D",
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
     assert abs(WF.energy_elec - (-5.211066791547)) < 10**-8

--- a/tests/test_unitary_coupled_cluster.py
+++ b/tests/test_unitary_coupled_cluster.py
@@ -111,7 +111,6 @@ def test_h2_431g_oouccd() -> None:
         A.hartree_fock.mo_coeff,
         A,
         excitations=["SAD"],
-        wavefunction_options={"include_active_kappa": False},
     )
     WF.run_wf_optimization(True)
     assert abs(WF.energy_elec - (-1.860533598715)) < 10**-8
@@ -159,7 +158,6 @@ def test_h4_sto3g_oouccd() -> None:
         A.hartree_fock.mo_coeff,
         A,
         excitations=["SAD"],
-        wavefunction_options={"include_active_kappa": False},
     )
     WF.run_wf_optimization(True)
     assert abs(WF.energy_elec - (-5.211066791547)) < 10**-8

--- a/tests/test_unitary_coupled_cluster.py
+++ b/tests/test_unitary_coupled_cluster.py
@@ -21,8 +21,10 @@ def test_heh_sto3g_hf() -> None:
     A.set_basis_set("sto-3g")
     Lambda_S, L_S = np.linalg.eigh(A.integral.overlap_matrix)
     S_sqrt = np.dot(np.dot(L_S, np.diag(Lambda_S ** (-1 / 2))), np.transpose(L_S))
-    WF = WaveFunctionUCC((2, 1), S_sqrt, A, "S")
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF = WaveFunctionUCC(
+        (2, 1), S_sqrt, A, excitations=["SAS"], wavefunction_options={"include_active_kappa": False}
+    )
+    WF.run_wf_optimization(True)
     assert abs(WF.energy_elec - (-4.262632309847)) < 10**-8
 
 
@@ -37,8 +39,10 @@ def test_lih_sto3g_hf() -> None:
     A.set_basis_set("sto-3g")
     Lambda_S, L_S = np.linalg.eigh(A.integral.overlap_matrix)
     S_sqrt = np.dot(np.dot(L_S, np.diag(Lambda_S ** (-1 / 2))), np.transpose(L_S))
-    WF = WaveFunctionUCC((2, 1), S_sqrt, A, "S")
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF = WaveFunctionUCC(
+        (2, 1), S_sqrt, A, excitations=["SAS"], wavefunction_options={"include_active_kappa": False}
+    )
+    WF.run_wf_optimization(True)
     assert abs(WF.energy_elec - (-8.862246324082243)) < 10**-8
 
 
@@ -54,8 +58,8 @@ def test_heh_sto3g_uccs() -> None:
     A.set_basis_set("sto-3g")
     Lambda_S, L_S = np.linalg.eigh(A.integral.overlap_matrix)
     S_sqrt = np.dot(np.dot(L_S, np.diag(Lambda_S ** (-1 / 2))), np.transpose(L_S))
-    WF = WaveFunctionUCC((2, 2), S_sqrt, A, "S")
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF = WaveFunctionUCC((2, 2), S_sqrt, A, excitations=["SAS"])
+    WF.run_wf_optimization(False)
     assert abs(WF.energy_elec - (-4.262632309847)) < 10**-8
 
 
@@ -85,9 +89,9 @@ def test_h10_sto3g_uccsd() -> None:
         (2, 2),
         A.hartree_fock.mo_coeff,
         A,
-        "SD",
+        excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(False)
     assert abs(WF.energy_elec - (-18.839645894737956)) < 10**-8
 
 
@@ -106,9 +110,10 @@ def test_h2_431g_oouccd() -> None:
         (2, 2),
         A.hartree_fock.mo_coeff,
         A,
-        "D",
+        excitations=["SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     assert abs(WF.energy_elec - (-1.860533598715)) < 10**-8
 
 
@@ -129,9 +134,10 @@ def test_h4_sto3g_oouccsd() -> None:
         (2, 2),
         A.hartree_fock.mo_coeff,
         A,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     assert abs(WF.energy_elec - (-5.211066791547)) < 10**-8
 
 
@@ -152,9 +158,10 @@ def test_h4_sto3g_oouccd() -> None:
         (2, 2),
         A.hartree_fock.mo_coeff,
         A,
-        "D",
+        excitations=["SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     assert abs(WF.energy_elec - (-5.211066791547)) < 10**-8
 
 
@@ -173,9 +180,9 @@ def test_h2_sto3g_uccsd_lr() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(False)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 1.015738) < 10**-4
@@ -206,14 +213,14 @@ def test_h4_sto3g_uccdq() -> None:
         (4, 4),
         A.hartree_fock.mo_coeff,
         A,
-        "DQ",
+        excitations=["SAD", "Q"],
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(False)
     assert abs(WF.energy_elec + A.molecule.nuclear_repulsion - (-1.968914822185857)) < 10**-7
 
 
 def test_h2_631g_hf_lr() -> None:
-    """Test Linear Response for oo-UCCSD(2,2)."""
+    """Test Linear Response for oo-UCCSD(2,1)."""
     SQobj = sq.SlowQuant()
     SQobj.set_molecule(
         """H  0.0   0.0  0.0;
@@ -227,9 +234,10 @@ def test_h2_631g_hf_lr() -> None:
         (2, 1),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.551961) < 10**-5
@@ -256,9 +264,10 @@ def test_h2_631g_oouccsd_lr() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True, tol=10**-11)
+    WF.run_wf_optimization(True, tol=10**-11)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.574413) < 10**-5
@@ -293,9 +302,9 @@ def test_h4_sto3g_uccsd_lr_naive() -> None:
         (4, 4),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization("BFGS")
     LR = naivelr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.162961) < 10**-5
@@ -374,9 +383,10 @@ def test_be_sto3g_uccsd_lr_naive() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.000001) < 10**-5
@@ -443,9 +453,10 @@ def test_lih_sto3g_uccsd_lr_naive() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.129476) < 10**-4
@@ -521,9 +532,10 @@ def test_LiH_sto3g_uccsd_lr() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     LR = naivelr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.129476) < 10**-4
@@ -601,7 +613,7 @@ def test_H4_sto3g_uccsdtq() -> None:
         (4, 4),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SDTQ",
+        excitations=["SAS", "SAD", "T", "Q"],
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(False)
     assert abs(WF.energy_elec - (-3.714153922167)) < 10**-8

--- a/tests/test_unitary_coupled_cluster.py
+++ b/tests/test_unitary_coupled_cluster.py
@@ -21,10 +21,8 @@ def test_heh_sto3g_hf() -> None:
     A.set_basis_set("sto-3g")
     Lambda_S, L_S = np.linalg.eigh(A.integral.overlap_matrix)
     S_sqrt = np.dot(np.dot(L_S, np.diag(Lambda_S ** (-1 / 2))), np.transpose(L_S))
-    WF = WaveFunctionUCC(
-        (2, 1), S_sqrt, A, excitations=["SAS"], wavefunction_options={"include_active_kappa": False}
-    )
-    WF.run_wf_optimization(True)
+    WF = WaveFunctionUCC((2, 1), S_sqrt, A, excitations=["SAS"], include_active_kappa=False)
+    WF.run_wf_optimization(orbital_optimization=True)
     assert abs(WF.energy_elec - (-4.262632309847)) < 10**-8
 
 
@@ -39,10 +37,8 @@ def test_lih_sto3g_hf() -> None:
     A.set_basis_set("sto-3g")
     Lambda_S, L_S = np.linalg.eigh(A.integral.overlap_matrix)
     S_sqrt = np.dot(np.dot(L_S, np.diag(Lambda_S ** (-1 / 2))), np.transpose(L_S))
-    WF = WaveFunctionUCC(
-        (2, 1), S_sqrt, A, excitations=["SAS"], wavefunction_options={"include_active_kappa": False}
-    )
-    WF.run_wf_optimization(True)
+    WF = WaveFunctionUCC((2, 1), S_sqrt, A, excitations=["SAS"], include_active_kappa=False)
+    WF.run_wf_optimization(orbital_optimization=True)
     assert abs(WF.energy_elec - (-8.862246324082243)) < 10**-8
 
 
@@ -59,7 +55,7 @@ def test_heh_sto3g_uccs() -> None:
     Lambda_S, L_S = np.linalg.eigh(A.integral.overlap_matrix)
     S_sqrt = np.dot(np.dot(L_S, np.diag(Lambda_S ** (-1 / 2))), np.transpose(L_S))
     WF = WaveFunctionUCC((2, 2), S_sqrt, A, excitations=["SAS"])
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - (-4.262632309847)) < 10**-8
 
 
@@ -91,7 +87,7 @@ def test_h10_sto3g_uccsd() -> None:
         A,
         excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - (-18.839645894737956)) < 10**-8
 
 
@@ -112,7 +108,7 @@ def test_h2_431g_oouccd() -> None:
         A,
         excitations=["SAD"],
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     assert abs(WF.energy_elec - (-1.860533598715)) < 10**-8
 
 
@@ -134,9 +130,9 @@ def test_h4_sto3g_oouccsd() -> None:
         A.hartree_fock.mo_coeff,
         A,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     assert abs(WF.energy_elec - (-5.211066791547)) < 10**-8
 
 
@@ -159,7 +155,7 @@ def test_h4_sto3g_oouccd() -> None:
         A,
         excitations=["SAD"],
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     assert abs(WF.energy_elec - (-5.211066791547)) < 10**-8
 
 
@@ -180,7 +176,7 @@ def test_h2_sto3g_uccsd_lr() -> None:
         SQobj,
         excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 1.015738) < 10**-4
@@ -213,7 +209,7 @@ def test_h4_sto3g_uccdq() -> None:
         A,
         excitations=["SAD", "Q"],
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec + A.molecule.nuclear_repulsion - (-1.968914822185857)) < 10**-7
 
 
@@ -233,9 +229,9 @@ def test_h2_631g_hf_lr() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.551961) < 10**-5
@@ -263,9 +259,9 @@ def test_h2_631g_oouccsd_lr() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True, tol=10**-11)
+    WF.run_wf_optimization(orbital_optimization=True, tol=10**-11)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.574413) < 10**-5
@@ -302,7 +298,7 @@ def test_h4_sto3g_uccsd_lr_naive() -> None:
         SQobj,
         excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization("BFGS")
+    WF.run_wf_optimization(orbital_optimization=False)
     LR = naivelr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.162961) < 10**-5
@@ -382,9 +378,9 @@ def test_be_sto3g_uccsd_lr_naive() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.000001) < 10**-5
@@ -452,9 +448,9 @@ def test_lih_sto3g_uccsd_lr_naive() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     LR = selfconsistentlr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.129476) < 10**-4
@@ -531,9 +527,9 @@ def test_LiH_sto3g_uccsd_lr() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     LR = naivelr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.129476) < 10**-4
@@ -613,5 +609,5 @@ def test_H4_sto3g_uccsdtq() -> None:
         SQobj,
         excitations=["SAS", "SAD", "T", "Q"],
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - (-3.714153922167)) < 10**-8

--- a/tests/test_unitary_coupled_cluster_all.py
+++ b/tests/test_unitary_coupled_cluster_all.py
@@ -30,9 +30,9 @@ def test_h2_sto3g_uccsd_lr() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization_1step("BFGS", False)
+    WF.run_wf_optimization(False)
     # SC
     LR = allselfconsistent.LinearResponse(
         WF,
@@ -66,9 +66,10 @@ def test_LiH_atmethods_energies() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     threshold = 10 ** (-3)
 
@@ -134,9 +135,10 @@ def test_LiH_naiveq_methods_energies() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     threshold = 10 ** (-5)
 
@@ -257,9 +259,10 @@ def test_LiH_naiveq_methods_matrices() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     threshold = 10 ** (-5)
 
@@ -321,9 +324,10 @@ def test_LiH_allproj_energies() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     threshold = 10 ** (-5)
 
@@ -368,9 +372,10 @@ def test_LiH_STproj_energies() -> None:
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     threshold = 10 ** (-5)
 

--- a/tests/test_unitary_coupled_cluster_all.py
+++ b/tests/test_unitary_coupled_cluster_all.py
@@ -32,7 +32,7 @@ def test_h2_sto3g_uccsd_lr() -> None:
         SQobj,
         excitations=["SAS", "SAD"],
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     # SC
     LR = allselfconsistent.LinearResponse(
         WF,
@@ -67,9 +67,9 @@ def test_LiH_atmethods_energies() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     threshold = 10 ** (-3)
 
@@ -136,9 +136,9 @@ def test_LiH_naiveq_methods_energies() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     threshold = 10 ** (-5)
 
@@ -260,9 +260,9 @@ def test_LiH_naiveq_methods_matrices() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     threshold = 10 ** (-5)
 
@@ -325,9 +325,9 @@ def test_LiH_allproj_energies() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     threshold = 10 ** (-5)
 
@@ -373,9 +373,9 @@ def test_LiH_STproj_energies() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     threshold = 10 ** (-5)
 

--- a/tests/test_unitary_product_state.py
+++ b/tests/test_unitary_product_state.py
@@ -27,7 +27,6 @@ def test_ups_naivelr() -> None:
         SQobj,
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("BFGS", True)
     LR = naivelr.LinearResponse(WF, excitations="SD")
@@ -145,7 +144,6 @@ def test_ups_water_44() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         "fUCCSD",
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("bfgs", True)
     # Changed threshold from 10-8 to 10-6, due to loss of precision in optimizer.
@@ -186,7 +184,6 @@ def test_saups_h2_3states() -> None:
         ),
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
-        include_active_kappa=True,
     )
 
     WF.run_wf_optimization_1step("BFGS", True)
@@ -230,7 +227,6 @@ def test_saups_h3_3states() -> None:
         ),
         "tUPS",
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
-        include_active_kappa=True,
     )
 
     WF.run_wf_optimization_2step("BFGS", True)
@@ -306,7 +302,6 @@ def test_ups_water_44_threaded() -> None:
         SQobj,
         "fUCCSD",
         ansatz_options={},
-        include_active_kappa=True,
     )
     WF.run_wf_optimization_1step("SLSQP", True)
     assert abs(WF.energy_elec - -83.97256228053688) < 10**-8
@@ -346,7 +341,6 @@ def test_saups_h3_3states_threaded() -> None:
         ),
         "tUPS",
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
-        include_active_kappa=True,
     )
 
     WF.run_wf_optimization_2step("BFGS", True)
@@ -386,7 +380,8 @@ def test_pptUPS_h2o() -> None:
         mo_coeff,
         integral_generator,
         "tUPS",  # our circuit Ansatz
-        ansatz_options={"n_layers": 1, "do_pp": True},  # we use 1 layer
+        ansatz_options={"n_layers": 1},  # we use 1 layer
+        wavefunction_options={"do_pp": True}
     )
 
     WF.run_wf_optimization_1step("bfgs", orbital_optimization=False)

--- a/tests/test_unitary_product_state.py
+++ b/tests/test_unitary_product_state.py
@@ -28,7 +28,7 @@ def test_ups_naivelr() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     LR = naivelr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.129476) < 10**-4
@@ -77,9 +77,10 @@ def test_LiH_sto3g_allST():
         (2, 2),
         SQobj.hartree_fock.mo_coeff,
         SQobj,
-        "SD",
+        excitations=["SAS", "SAD"],
+        wavefunction_options={"include_active_kappa": False},
     )
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
     WF2 = WaveFunctionUPS(
         (2, 2),
         WF.c_mo,
@@ -87,7 +88,7 @@ def test_LiH_sto3g_allST():
         "tUPS",
         ansatz_options={"n_layers": 1},
     )
-    WF2.run_wf_optimization_1step("BFGS", False)
+    WF2.run_wf_optimization(False)
     # Linear Response
     LR = allstlr.LinearResponse(
         WF2,
@@ -145,7 +146,7 @@ def test_ups_water_44() -> None:
         SQobj,
         "fUCCSD",
     )
-    WF.run_wf_optimization_1step("bfgs", True)
+    WF.run_wf_optimization(True)
     # Changed threshold from 10-8 to 10-6, due to loss of precision in optimizer.
     # Change back again when optimization code has been made more stable.
     assert abs(WF.energy_elec - -84.00619955119978) < 10**-6
@@ -186,7 +187,7 @@ def test_saups_h2_3states() -> None:
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
 
-    WF.run_wf_optimization_1step("BFGS", True)
+    WF.run_wf_optimization(True)
 
     assert abs(WF.excitation_energies[0] - 0.974553) < 10**-6
     assert abs(WF.excitation_energies[1] - 1.632364) < 10**-6
@@ -229,7 +230,7 @@ def test_saups_h3_3states() -> None:
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
     )
 
-    WF.run_wf_optimization_2step("BFGS", True)
+    WF.run_wf_optimization_2step(True, orbital_optimization={"opt_type": "2step"})
 
     assert abs(WF.excitation_energies[0] - 0.838466) < 10**-6
     assert abs(WF.excitation_energies[1] - 0.838466) < 10**-6
@@ -254,9 +255,9 @@ def test_sa_doubles() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         ansatz="fUCC",
-        ansatz_options={"n_layers": 1, "SAS": True, "SAD": True},
+        ansatz_options={"n_layers": 1, "excitations": ["SAS", "SAD"]},
     )
-    WF.run_wf_optimization_1step("BFGS")
+    WF.run_wf_optimization(False)
     assert abs(WF.energy_elec - -8.874521029611891) < 10**-8
 
 
@@ -277,9 +278,9 @@ def test_SA_sa_doubles() -> None:
         SQobj,
         ([[1]], [["111100000000"]]),
         ansatz="SAfUCCSD",
-        ansatz_options={"n_layers": 1, "SAS": True, "SAD": True},
+        ansatz_options={"n_layers": 1, "excitations": ["SAS", "SAD"]},
     )
-    WF.run_wf_optimization_1step("BFGS")
+    WF.run_wf_optimization(False)
     assert abs(WF.energy_states[0] - -8.874521029611891) < 10**-8
 
 
@@ -303,7 +304,7 @@ def test_ups_water_44_threaded() -> None:
         "fUCCSD",
         ansatz_options={},
     )
-    WF.run_wf_optimization_1step("SLSQP", True)
+    WF.run_wf_optimization(True, optimization_options={"1step_optimizer": "SLSQP"})
     assert abs(WF.energy_elec - -83.97256228053688) < 10**-8
     nb.set_num_threads(1)
 
@@ -342,8 +343,7 @@ def test_saups_h3_3states_threaded() -> None:
         "tUPS",
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
     )
-
-    WF.run_wf_optimization_2step("BFGS", True)
+    WF.run_wf_optimization(True, optimization_options={"opt_type": "2step"})
 
     assert abs(WF.excitation_energies[0] - 0.838466) < 10**-6
     assert abs(WF.excitation_energies[1] - 0.838466) < 10**-6
@@ -384,7 +384,7 @@ def test_pptUPS_h2o() -> None:
         wavefunction_options={"do_pp": True},
     )
 
-    WF.run_wf_optimization_1step("bfgs", orbital_optimization=False)
+    WF.run_wf_optimization(False)
 
     assert abs(WF.energy_elec + 83.96387402720552) < 10**-6
 
@@ -408,7 +408,7 @@ def test_ups_n2_fuccsdtq56() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         "fUCC",
-        ansatz_options={"S": True, "D": True, "T": True, "Q": True, "5": True, "6": True},
+        ansatz_options={"excitations": ["S", "D", "T", "Q", "5", "6"]},
     )
-    WF.run_wf_optimization_1step("bfgs", False)
+    WF.run_wf_optimization(False)
     assert abs(WF.energy_elec - -131.1965135680604533) < 10**-6

--- a/tests/test_unitary_product_state.py
+++ b/tests/test_unitary_product_state.py
@@ -381,7 +381,7 @@ def test_pptUPS_h2o() -> None:
         integral_generator,
         "tUPS",  # our circuit Ansatz
         ansatz_options={"n_layers": 1},  # we use 1 layer
-        wavefunction_options={"do_pp": True}
+        wavefunction_options={"do_pp": True},
     )
 
     WF.run_wf_optimization_1step("bfgs", orbital_optimization=False)

--- a/tests/test_unitary_product_state.py
+++ b/tests/test_unitary_product_state.py
@@ -1,6 +1,7 @@
 # type: ignore
 import numba as nb
 import numpy as np
+import pyscf
 
 import slowquant.SlowQuant as sq
 import slowquant.unitary_coupled_cluster.linear_response.allstatetransfer as allstlr
@@ -191,7 +192,7 @@ def test_saups_h2_3states() -> None:
 
     assert abs(WF.excitation_energies[0] - 0.974553) < 10**-6
     assert abs(WF.excitation_energies[1] - 1.632364) < 10**-6
-    osc = WF.get_oscillator_strenghts()
+    osc = WF.get_oscillator_strengths()
     assert abs(osc[0] - 0.8706) < 10**-3
     assert abs(osc[1] - 0.0) < 10**-3
 
@@ -234,7 +235,7 @@ def test_saups_h3_3states() -> None:
 
     assert abs(WF.excitation_energies[0] - 0.838466) < 10**-6
     assert abs(WF.excitation_energies[1] - 0.838466) < 10**-6
-    osc = WF.get_oscillator_strenghts()
+    osc = WF.get_oscillator_strengths()
     assert abs(osc[0] - 0.7569) < 10**-3
     assert abs(osc[1] - 0.7569) < 10**-3
 
@@ -346,7 +347,7 @@ def test_saups_h3_3states_threaded() -> None:
 
     assert abs(WF.excitation_energies[0] - 0.838466) < 10**-6
     assert abs(WF.excitation_energies[1] - 0.838466) < 10**-6
-    osc = WF.get_oscillator_strenghts()
+    osc = WF.get_oscillator_strengths()
     assert abs(osc[0] - 0.7569) < 10**-3
     assert abs(osc[1] - 0.7569) < 10**-3
     nb.set_num_threads(1)
@@ -411,3 +412,74 @@ def test_ups_n2_fuccsdtq56() -> None:
     )
     WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - -131.1965135680604533) < 10**-6
+
+
+def test_ups_pp_lr() -> None:
+    """Test that the linear response are independent of reference for fUCCSD.
+
+    When using a fUCCSD wave function, the linear response results should be
+    independent of reference (if it is closed-shell).
+    """
+    SQobj = sq.SlowQuant()
+    SQobj.set_molecule(
+        """O   0.0  0.0           0.1035174918;
+    H   0.0  0.7955612117 -0.4640237459;
+    H   0.0 -0.7955612117 -0.4640237459;""",
+        distance_unit="angstrom",
+    )
+    SQobj.set_basis_set("STO-3G")
+    SQobj.init_hartree_fock()
+    SQobj.hartree_fock.run_restricted_hartree_fock()
+    WF = WaveFunctionUPS(
+        (4, 4),
+        SQobj.hartree_fock.mo_coeff,
+        SQobj,
+        "fUCCSD",
+        ansatz_options={"n_layers": 2},
+    )
+    WF.run_wf_optimization(orbital_optimization=False)
+    # Hack to turn off orbital part in response.
+    WF.kappa_no_activeactive_idx = []
+    WF.kappa_no_activeactive_idx_dagger = []
+    LR = naivelr.LinearResponse(WF, excitations="SD")
+    LR.calc_excitation_energies()
+    ppWF = WaveFunctionUPS(
+        (4, 4),
+        SQobj.hartree_fock.mo_coeff,
+        SQobj,
+        "fUCCSD",
+        ansatz_options={"n_layers": 2},
+        do_pp=True,
+    )
+    ppWF.run_wf_optimization(orbital_optimization=False)
+    # Hack to turn off orbital part in response.
+    ppWF.kappa_no_activeactive_idx = []
+    ppWF.kappa_no_activeactive_idx_dagger = []
+    ppLR = naivelr.LinearResponse(ppWF, excitations="SD")
+    ppLR.calc_excitation_energies()
+    for exc, ppexc in zip(LR.excitation_energies, ppLR.excitation_energies):
+        assert abs(exc - ppexc) < 10**-6
+    for osc, pposc in zip(LR.get_oscillator_strength(), ppLR.get_oscillator_strength()):
+        assert abs(osc - pposc) < 10**-3
+
+
+def test_H3_fuccsdt_openshell() -> None:
+    """Test UPS wavefunction works with a open-shell reference."""
+    mol = pyscf.M(
+        atom="H   0.0 0.0 0.0; H   1.0 0.0 0.0; H   0.5 0.8660254038  0.0;",
+        basis="sto-3g",
+        unit="angstrom",
+        spin=1,
+    )
+    rohf = pyscf.scf.ROHF(mol).run()
+
+    WF = WaveFunctionUPS(
+        (3, 3),
+        rohf.mo_coeff,
+        mol,
+        "fUCC",
+        ansatz_options={"excitations": ["S", "D", "T"]},
+        reference_determinant="111000",
+    )
+    WF.run_wf_optimization(orbital_optimization=False)
+    assert abs(WF.energy_elec - -2.951920725362) < 10**-7

--- a/tests/test_unitary_product_state.py
+++ b/tests/test_unitary_product_state.py
@@ -28,7 +28,7 @@ def test_ups_naivelr() -> None:
         "tUPS",
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     LR = naivelr.LinearResponse(WF, excitations="SD")
     LR.calc_excitation_energies()
     assert abs(LR.excitation_energies[0] - 0.129476) < 10**-4
@@ -78,9 +78,9 @@ def test_LiH_sto3g_allST():
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         excitations=["SAS", "SAD"],
-        wavefunction_options={"include_active_kappa": False},
+        include_active_kappa=False,
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     WF2 = WaveFunctionUPS(
         (2, 2),
         WF.c_mo,
@@ -88,7 +88,7 @@ def test_LiH_sto3g_allST():
         "tUPS",
         ansatz_options={"n_layers": 1},
     )
-    WF2.run_wf_optimization(False)
+    WF2.run_wf_optimization(orbital_optimization=False)
     # Linear Response
     LR = allstlr.LinearResponse(
         WF2,
@@ -146,7 +146,7 @@ def test_ups_water_44() -> None:
         SQobj,
         "fUCCSD",
     )
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
     # Changed threshold from 10-8 to 10-6, due to loss of precision in optimizer.
     # Change back again when optimization code has been made more stable.
     assert abs(WF.energy_elec - -84.00619955119978) < 10**-6
@@ -187,7 +187,7 @@ def test_saups_h2_3states() -> None:
         ansatz_options={"n_layers": 1, "skip_last_singles": True},
     )
 
-    WF.run_wf_optimization(True)
+    WF.run_wf_optimization(orbital_optimization=True)
 
     assert abs(WF.excitation_energies[0] - 0.974553) < 10**-6
     assert abs(WF.excitation_energies[1] - 1.632364) < 10**-6
@@ -230,7 +230,7 @@ def test_saups_h3_3states() -> None:
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
     )
 
-    WF.run_wf_optimization_2step(True, orbital_optimization={"opt_type": "2step"})
+    WF.run_wf_optimization(orbital_optimization=True, opt_type="2step")
 
     assert abs(WF.excitation_energies[0] - 0.838466) < 10**-6
     assert abs(WF.excitation_energies[1] - 0.838466) < 10**-6
@@ -257,7 +257,7 @@ def test_sa_doubles() -> None:
         ansatz="fUCC",
         ansatz_options={"n_layers": 1, "excitations": ["SAS", "SAD"]},
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - -8.874521029611891) < 10**-8
 
 
@@ -280,7 +280,7 @@ def test_SA_sa_doubles() -> None:
         ansatz="SAfUCCSD",
         ansatz_options={"n_layers": 1, "excitations": ["SAS", "SAD"]},
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimizer=False)
     assert abs(WF.energy_states[0] - -8.874521029611891) < 10**-8
 
 
@@ -302,9 +302,8 @@ def test_ups_water_44_threaded() -> None:
         SQobj.hartree_fock.mo_coeff,
         SQobj,
         "fUCCSD",
-        ansatz_options={},
     )
-    WF.run_wf_optimization(True, optimization_options={"1step_optimizer": "SLSQP"})
+    WF.run_wf_optimization(orbital_optimization=True, one_step_optimizer="SLSQP")
     assert abs(WF.energy_elec - -83.97256228053688) < 10**-8
     nb.set_num_threads(1)
 
@@ -343,7 +342,7 @@ def test_saups_h3_3states_threaded() -> None:
         "tUPS",
         ansatz_options={"n_layers": 2, "skip_last_singles": True},
     )
-    WF.run_wf_optimization(True, optimization_options={"opt_type": "2step"})
+    WF.run_wf_optimization(orbital_optimization=True, opt_type="2step")
 
     assert abs(WF.excitation_energies[0] - 0.838466) < 10**-6
     assert abs(WF.excitation_energies[1] - 0.838466) < 10**-6
@@ -381,10 +380,10 @@ def test_pptUPS_h2o() -> None:
         integral_generator,
         "tUPS",  # our circuit Ansatz
         ansatz_options={"n_layers": 1},  # we use 1 layer
-        wavefunction_options={"do_pp": True},
+        do_pp=True,
     )
 
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
 
     assert abs(WF.energy_elec + 83.96387402720552) < 10**-6
 
@@ -410,5 +409,5 @@ def test_ups_n2_fuccsdtq56() -> None:
         "fUCC",
         ansatz_options={"excitations": ["S", "D", "T", "Q", "5", "6"]},
     )
-    WF.run_wf_optimization(False)
+    WF.run_wf_optimization(orbital_optimization=False)
     assert abs(WF.energy_elec - -131.1965135680604533) < 10**-6


### PR DESCRIPTION
Cleanup of all of the wavefunction classes.

This PR comes with some minor API breaking changes:

- `do_pp` is now an argument for the wavefunction class init.
- `run_wf_optimization_1step`and `run_wf_optimization_2step` are now called through `run_wf_optimization`.
- `ansatz_options` now takes a list of excitation orders instead of a bool per excitation order.
- `WavefunctionUCC` now takes a list of excitation orders instead of a string of excitation orders.
- `force_no_pp_mos` has been removed from `WaveFunctionCircuit` as it is not needed for the conversion between state-vector wavefunction and circuit wavefunction.
- `include_active_kappa` is now true by default.

The following is gained:

- The logic of constructing the different orbital indexing lists is much simpler now in all of the wavefunction classes.
- All of the wavefunction classes can now run with any reference (active space) determinant, allowing for open-shell high-spin calculations.
- Linear response now works when using a pp reference determinant.
- Optimization now allows for orbital optimization only.