### PR TITLE
Qiskit 2 5

### DIFF
--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -14,7 +14,8 @@ from qiskit.primitives import (
     BaseSamplerV2,
 )
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.transpiler import PassManager
+from qiskit.transpiler import PassManager, StagedPassManager
+from qiskit.transpiler.passes import Optimize1qGatesDecomposition
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_nature.second_q.circuit.library import HartreeFock
 from qiskit_nature.second_q.mappers import JordanWignerMapper
@@ -534,10 +535,14 @@ class QuantumInterface:
             )
 
         # Transpile X and Y measurement gates: only translation to basis gates and optimization.
-        self._transp_xy = [
-            self._pass_manager.optimization.run(self._pass_manager.translation.run(to_CBS_measurement("X"))),
-            self._pass_manager.optimization.run(self._pass_manager.translation.run(to_CBS_measurement("Y"))),
-        ]
+        backend = self.pass_manager_options.get("backend")
+        basis_gates = backend.operation_names if backend is not None else None
+        light_pass_manager = StagedPassManager(
+            stages=("translation", "optimization"),
+            translation=self._pass_manager.translation,
+            optimization=PassManager([Optimize1qGatesDecomposition(basis=basis_gates)]),
+        )
+        self._transp_xy = light_pass_manager.run([to_CBS_measurement("X"), to_CBS_measurement("Y")])
 
         return circuit_return
 

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -410,6 +410,8 @@ class QuantumInterface:
                 self.num_orbs,
                 self.num_elec,
             )
+            # Reset saver
+            self._reset_cliques()
 
     def redo_M_mitigation(self, shots: int | None = None) -> None:
         """Redo M_mitigation.
@@ -1361,6 +1363,8 @@ class QuantumInterface:
             shots = self.shots
         if overwrite_shots is not None:
             print("Warning: Overwriting QI shots has been used.")
+            if self._circuit_multipl > 1:
+                print("Warning: Circuit multiplier is switched on to ", self._circuit_multipl)
             shots = overwrite_shots
 
         if isinstance(paulis, str):
@@ -1432,8 +1436,8 @@ class QuantumInterface:
             # Run sampler
             job = self._primitive.run(circuits, parameter_values=parameter_values, shots=shots)
 
-        if self.shots is not None:  # check if ideal simulator
-            self.total_shots_used += self.shots * num_paulis * num_circuits
+        if shots is not None:  # check if ideal simulator
+            self.total_shots_used += shots * self._circuit_multipl * num_paulis * num_circuits
         self.total_device_calls += 1
         self.total_paulis_evaluated += num_paulis * num_circuits
 

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -1629,6 +1629,7 @@ class QuantumInterface:
             pickle.dump(self.saver, file)
         with open(filename + "_info.txt", "w") as f:
             f.write(self._info_string())
+            f.write(f"\nAnsatz parameters:\n{self.parameters}")
 
     def load_paulis_from_file(self, filename: str) -> None:
         """Load Pauli strings and their distributions from a file.
@@ -1645,7 +1646,7 @@ class QuantumInterface:
         if isinstance(self.ansatz, QuantumCircuit):
             data = f"Your settings are:\n {'Ansatz:':<20} {'custom circuit'}\n {'Number of shots:':<20} {self.shots}\n"
         else:
-            data = f"Your settings are:\n {'Ansatz:':<20} {self.ansatz}\n {'Number of shots:':<20} {self.shots}\n"
+            data = f"Your settings are:\n {'Ansatz:':<20} {self.ansatz}\n {'Ansatz options:':<20} {self.ansatz_options}\n {'Number of shots:':<20} {self.shots}\n"
         data += f" {'ISA':<20} {self.ISA}\n {'Primitive:':<20} {self._primitive.__class__.__name__}"
         if self.ISA:
             if self._transpiled:

--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -1627,6 +1627,8 @@ class QuantumInterface:
         """
         with open(filename, "wb") as file:
             pickle.dump(self.saver, file)
+        with open(filename + "_info.txt", "w") as f:
+            f.write(self._info_string())
 
     def load_paulis_from_file(self, filename: str) -> None:
         """Load Pauli strings and their distributions from a file.
@@ -1638,8 +1640,8 @@ class QuantumInterface:
             self.saver = pickle.load(file)
         print(f"Loaded Pauli strings from {filename}.")
 
-    def get_info(self) -> None:
-        """Get infos about settings."""
+    def _info_string(self) -> str:
+        """Get infos about settings as string."""
         if isinstance(self.ansatz, QuantumCircuit):
             data = f"Your settings are:\n {'Ansatz:':<20} {'custom circuit'}\n {'Number of shots:':<20} {self.shots}\n"
         else:
@@ -1664,5 +1666,9 @@ class QuantumInterface:
                     self._primitive.options, "twirling"
                 ):
                     data += f"\n {'Pauli twirling:':<20} {self._primitive.options.twirling.enable_gates}\n {'Dynamic decoupling:':<20} {self._primitive.options.dynamical_decoupling.enable}"
+        data += f"\nMitigation flags:\n{self.mitigation_flags.status_report()}"
+        return data
 
-        print(f"{data}\nMitigation flags:\n{self.mitigation_flags.status_report()}")
+    def get_info(self) -> None:
+        """Print infos about settings."""
+        print(f"{self._info_string()}")

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -31,10 +31,10 @@ from slowquant.unitary_coupled_cluster.ucc_wavefunction import WaveFunctionUCC
 from slowquant.unitary_coupled_cluster.ups_wavefunction import WaveFunctionUPS
 
 noise_model = NoiseModel()
-noise_model.add_all_qubit_quantum_error(depolarizing_error(0.005, 1), ["u1", "u2", "u3"])
-noise_model.add_all_qubit_quantum_error(depolarizing_error(0.02, 2), ["cx"])
-noise_model.add_all_qubit_quantum_error(amplitude_damping_error(0.02), ["u1", "u2", "u3"], warnings=False)
-noise_model.add_all_qubit_quantum_error(phase_damping_error(0.03), ["u1", "u2", "u3"], warnings=False)
+noise_model.add_all_qubit_quantum_error(depolarizing_error(0.005, 1), ["rz", "sx", "x"])
+noise_model.add_all_qubit_quantum_error(depolarizing_error(0.02, 2), ["cz"])
+noise_model.add_all_qubit_quantum_error(amplitude_damping_error(0.02), ["rz", "sx", "x"], warnings=False)
+noise_model.add_all_qubit_quantum_error(phase_damping_error(0.03), ["rz", "sx", "x"], warnings=False)
 noise_model.add_all_qubit_readout_error(ReadoutError([[0.95, 0.05], [0.1, 0.9]]))
 
 
@@ -709,7 +709,10 @@ def test_mitigation_nocm() -> None:
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
-    sampler = SamplerAer(backend_options={"noise_model": noise_model})
+    sampler = SamplerAer(
+        backend_options={"noise_model": noise_model},
+        skip_transpilation=True,
+    )
     mapper = JordanWignerMapper()
     QI = QuantumInterface(
         sampler,
@@ -730,23 +733,23 @@ def test_mitigation_nocm() -> None:
     )
     qWF.thetas = WF.thetas
 
-    assert abs(qWF._calc_energy_elec() - -9.418383329562078) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.631094873717291) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0]
 
     QI.update_mitigation_flags(do_postselection=True)
-    assert abs(qWF._calc_energy_elec() - -9.602601639646656) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.695213772925092) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8]
 
     QI.update_mitigation_flags(do_postselection=False, do_M_ansatz0=True)
-    assert abs(qWF._calc_energy_elec() - -9.683988916881479) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.689807552229608) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8, 3]
 
     QI.update_mitigation_flags(do_postselection=True)
-    assert abs(qWF._calc_energy_elec() - -9.70319667962837) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.712408682894697) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8, 3, 11]
 
     QI.update_mitigation_flags(do_M_ansatz0_plus=True)
-    assert abs(qWF._calc_energy_elec() - -9.70319667962837) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.712408682894697) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8, 3, 11, 15]
 
 
@@ -774,7 +777,10 @@ def test_mitigation() -> None:
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
-    sampler = SamplerAer(backend_options={"noise_model": noise_model})
+    sampler = SamplerAer(
+        backend_options={"noise_model": noise_model},
+        skip_transpilation=True,
+    )
     mapper = JordanWignerMapper()
     QI = QuantumInterface(
         sampler,
@@ -785,7 +791,13 @@ def test_mitigation() -> None:
         do_M_mitigation=False,
         do_M_ansatz0=False,
         do_postselection=False,
-        pass_manager_options={"backend": FakeTorino(), "seed_transpiler": 1234},
+        pass_manager_options={
+            "backend": FakeTorino(),
+            "initial_layout": [99, 98, 80, 92],
+            "optimization_level": 1,
+            "routing_method": "basic",
+            "seed_transpiler": 1234,
+        },
     )
 
     qWF = WaveFunctionCircuit(
@@ -796,23 +808,23 @@ def test_mitigation() -> None:
     )
     qWF.thetas = WF.thetas
 
-    assert abs(qWF._calc_energy_elec() - -9.233747228500063) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.09907097331813) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0]
 
     QI.update_mitigation_flags(do_postselection=True)
-    assert abs(qWF._calc_energy_elec() - -9.530550958752345) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.289142691443796) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8]
 
     QI.update_mitigation_flags(do_postselection=False, do_M_ansatz0=True)
-    assert abs(qWF._calc_energy_elec() - -9.66182116795791) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.499753131080157) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8, 3]
 
     QI.update_mitigation_flags(do_postselection=True)
-    assert abs(qWF._calc_energy_elec() - -9.712021766284208) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.55460043872056) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8, 3, 11]
 
     QI.update_mitigation_flags(do_M_ansatz0_plus=True)
-    assert abs(qWF._calc_energy_elec() - -9.712021766284208) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.55460043872056) < 10**-6  # type: ignore
     assert list(QI.saver[12].cliques[0].distr.data.keys()) == [0, 8, 3, 11, 15]
 
 
@@ -914,7 +926,10 @@ def test_state_average_M() -> None:
     )
     WF.run_wf_optimization_1step("BFGS")
 
-    sampler = SamplerAer(backend_options={"noise_model": noise_model})
+    sampler = SamplerAer(
+        backend_options={"noise_model": noise_model},
+        skip_transpilation=True,
+    )
     mapper = JordanWignerMapper()
     QI = QuantumInterface(
         sampler,
@@ -925,7 +940,13 @@ def test_state_average_M() -> None:
         do_M_mitigation=True,
         do_M_ansatz0=True,
         do_postselection=True,
-        pass_manager_options={"backend": FakeTorino(), "seed_transpiler": 1234},
+        pass_manager_options={
+            "backend": FakeTorino(),
+            "initial_layout": [99, 98, 80, 92],
+            "optimization_level": 1,
+            "routing_method": "basic",
+            "seed_transpiler": 1234,
+        },
     )
 
     QWF = WaveFunctionSACircuit(
@@ -946,7 +967,7 @@ def test_state_average_M() -> None:
     )
     QWF.thetas = WF.thetas
 
-    assert abs(QWF._calc_energy_elec() + 1.4240939758312483) < 10**-6  # type: ignore
+    assert abs(QWF._calc_energy_elec() + 1.3749928877432358) < 10**-6  # type: ignore
 
 
 def test_state_average_Mplus() -> None:
@@ -1006,29 +1027,40 @@ def test_state_average_Mplus() -> None:
 
     assert abs(WF._sa_energy - QWF._calc_energy_elec()) < 10**-6  # type: ignore
 
-    sampler = SamplerAer(backend_options={"noise_model": noise_model})
+    sampler = SamplerAer(
+        backend_options={"noise_model": noise_model},
+        skip_transpilation=True,
+    )
     QWF.change_primitive(sampler)
 
     QI.shots = None
     QI.ISA = True
-    QI.update_pass_manager({"backend": FakeTorino(), "seed_transpiler": 1234})
+    QI.update_pass_manager(
+        {
+            "backend": FakeTorino(),
+            "initial_layout": [99, 98, 80, 92],
+            "optimization_level": 1,
+            "routing_method": "basic",
+            "seed_transpiler": 1234,
+        }
+    )
 
     # No EM
     QI._reset_cliques()
-    assert abs(QWF._calc_energy_elec() + 9.436258997213987) < 10**-6  # type: ignore  # CSFs option 1
+    assert abs(QWF._calc_energy_elec() + 9.374249021996663) < 10**-6  # type: ignore  # CSFs option 1
 
     # EM with M_Ansatz0
     QI.update_mitigation_flags(do_M_mitigation=True, do_M_ansatz0=True)
 
-    assert abs(QWF._calc_energy_elec() + 9.596224644030176) < 10**-6  # type: ignore  # CSFs option 4
+    assert abs(QWF._calc_energy_elec() + 9.398404469079898) < 10**-6  # type: ignore  # CSFs option 4
 
     # EM with M_Ansatz0+
     QI.update_mitigation_flags(do_M_ansatz0_plus=True)
-    assert abs(QWF._calc_energy_elec() + 9.608563673328995) < 10**-6  # type: ignore  # CSFs option 1
+    assert abs(QWF._calc_energy_elec() + 9.426250418342013) < 10**-6  # type: ignore  # CSFs option 1
 
     # EM with M_Ansatz0 and postselection
     QI.update_mitigation_flags(do_postselection=True, do_M_ansatz0_plus=False)
-    assert abs(QWF._calc_energy_elec() + 9.638637411200133) < 10**-6  # type: ignore  # CSFs option 4
+    assert abs(QWF._calc_energy_elec() + 9.637857456768002) < 10**-6  # type: ignore  # CSFs option 4
 
 
 def test_no_saving() -> None:
@@ -1092,15 +1124,26 @@ def test_no_saving() -> None:
     QI._do_cliques = False
     assert abs(WF._sa_energy - QWF._calc_energy_elec()) < 10**-6  # type: ignore
 
-    sampler = SamplerAer(backend_options={"noise_model": noise_model})
+    sampler = SamplerAer(
+        backend_options={"noise_model": noise_model},
+        skip_transpilation=True,
+    )
     QWF.change_primitive(sampler)
 
     QI.shots = None
     QI.ISA = True
-    QI.update_pass_manager({"backend": FakeTorino(), "seed_transpiler": 1234})
+    QI.update_pass_manager(
+        {
+            "backend": FakeTorino(),
+            "initial_layout": [99, 98, 80, 92],
+            "optimization_level": 1,
+            "routing_method": "basic",
+            "seed_transpiler": 1234,
+        }
+    )
 
     QI.update_mitigation_flags(do_postselection=False, do_M_ansatz0=True)
-    assert abs(QWF._calc_energy_elec() + 9.596224644030176) < 10**-6  # type: ignore
+    assert abs(QWF._calc_energy_elec() + 9.398404469079898) < 10**-6  # type: ignore
 
 
 def test_variance_nocm() -> None:
@@ -1127,7 +1170,10 @@ def test_variance_nocm() -> None:
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
-    sampler = SamplerAer(backend_options={"noise_model": noise_model})
+    sampler = SamplerAer(
+        backend_options={"noise_model": noise_model},
+        skip_transpilation=True,
+    )
     mapper = JordanWignerMapper()
     QI = QuantumInterface(
         sampler,
@@ -1148,12 +1194,12 @@ def test_variance_nocm() -> None:
     )
     qWF.thetas = WF.thetas
 
-    assert abs(qWF._calc_energy_elec() - -9.418383329562078) < 10**-6  # type: ignore
-    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.10213270381462243) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.631094873717291) < 10**-6  # type: ignore
+    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.0567009117091328) < 10**-6  # type: ignore
 
     QI.update_mitigation_flags(do_postselection=True)
-    assert abs(qWF._calc_energy_elec() - -9.602601639646656) < 10**-6  # type: ignore
-    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.052830412154174874) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.695213772925092) < 10**-6  # type: ignore
+    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.028179912484011638) < 10**-6  # type: ignore
 
 
 def test_variance() -> None:
@@ -1180,7 +1226,10 @@ def test_variance() -> None:
     )
     WF.run_wf_optimization_1step("BFGS", True)
 
-    sampler = SamplerAer(backend_options={"noise_model": noise_model})
+    sampler = SamplerAer(
+        backend_options={"noise_model": noise_model},
+        skip_transpilation=True,
+    )
     mapper = JordanWignerMapper()
     QI = QuantumInterface(
         sampler,
@@ -1191,7 +1240,13 @@ def test_variance() -> None:
         do_M_mitigation=False,
         do_M_ansatz0=False,
         do_postselection=False,
-        pass_manager_options={"backend": FakeTorino(), "seed_transpiler": 1234},
+        pass_manager_options={
+            "backend": FakeTorino(),
+            "initial_layout": [99, 98, 80, 92],
+            "optimization_level": 1,
+            "routing_method": "basic",
+            "seed_transpiler": 1234,
+        },
     )
 
     qWF = WaveFunctionCircuit(
@@ -1202,14 +1257,14 @@ def test_variance() -> None:
     )
     qWF.thetas = WF.thetas
 
-    assert abs(qWF._calc_energy_elec() - -9.233747228500063) < 10**-6  # type: ignore
-    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.13667860748213662) < 10**-6  # type: ignore
-    assert abs(QI.quantum_variance(qWF._get_hamiltonian()) - 0.2176947578575442) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.09907097331813) < 10**-6  # type: ignore
+    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.1531370657002356) < 10**-6  # type: ignore
+    assert abs(QI.quantum_variance(qWF._get_hamiltonian()) - 0.16583651217084236) < 10**-6  # type: ignore
 
     QI.update_mitigation_flags(do_postselection=True)
-    assert abs(qWF._calc_energy_elec() - -9.530550958752345) < 10**-6  # type: ignore
-    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.08149072047975339) < 10**-6  # type: ignore
-    assert abs(QI.quantum_variance(qWF._get_hamiltonian()) - 0.12548161863195212) < 10**-6  # type: ignore
+    assert abs(qWF._calc_energy_elec() - -9.289142691443796) < 10**-6  # type: ignore
+    assert abs(QI.quantum_variance(qWF._get_hamiltonian(), do_no_corr=True) - 0.13591141770369639) < 10**-6  # type: ignore
+    assert abs(QI.quantum_variance(qWF._get_hamiltonian()) - 0.16411873796330764) < 10**-6  # type: ignore
 
 
 def test_upslayout_input() -> None:

--- a/tests/test_qiskit_interface.py
+++ b/tests/test_qiskit_interface.py
@@ -680,8 +680,6 @@ def test_H2_sampler_layout() -> None:
 
     QI.update_pass_manager({"backend": FakeTorino()})
 
-    QI._reset_cliques()
-
     assert np.allclose(qWF._calc_energy_elec(), -1.6303275411526188, atol=10**-6)
 
 


### PR DESCRIPTION
Make SlowQuant compatible with Qiskit 2.2 - 2.5. 
The changes were needed due to changes of the pass manager that introduced backend dependence in the optimization stage.

Additionally, Qiskit 2.5 has introduced changes to the transpilation process: 

> New default two-qubit transpiler optimizations. Qiskit’s default two-qubit resynthesis optimization (enabled at levels 2 and 3 in the preset pipelines) now uses a new [TwoQubitPeepholeOptimization](https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.transpiler.passes.TwoQubitPeepholeOptimization) pass. Compared to the previous combination of [ConsolidateBlocks](https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.transpiler.passes.ConsolidateBlocks) and [UnitarySynthesis](https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.transpiler.passes.UnitarySynthesis), this is more performant and better at selecting the highest-fidelity decomposition.

https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes/2.5

The Quantum Interface tests have been made less dependent on such changes. Tests are now also compliant with any Qiskit version >= 2.2. 


