### PR TITLE
Bug fix adding post-selection on top of M0 results

### DIFF
--- a/slowquant/qiskit_interface/interface.py
+++ b/slowquant/qiskit_interface/interface.py
@@ -1063,7 +1063,17 @@ class QuantumInterface:
 
             if len(head_mit) != 0:
                 if self.mitigation_flags.do_M_mitigation:  # apply error mitigation if requested
-                    self._apply_M_mitigation(distr_raw, run_circuit, circuit_M)
+                    # Reuse distributions that already have the requested M mitigation.
+                    M_only_flags = copy.copy(self.mitigation_flags)
+                    M_only_flags.do_postselection = False
+                    empty_M_heads = self.saver[det_int].get_empty_heads(M_only_flags)
+                    if len(empty_M_heads) == 0:
+                        distr_raw = [
+                            distr.copy()
+                            for distr in self.saver[det_int].get_distr_heads(head_mit, M_only_flags)
+                        ]
+                    else:
+                        self._apply_M_mitigation(distr_raw, run_circuit, circuit_M)
 
                 if self.mitigation_flags.do_postselection:  # apply post-selection if requested
                     self._apply_postselection(distr_raw, head_mit)

--- a/slowquant/qiskit_interface/util.py
+++ b/slowquant/qiskit_interface/util.py
@@ -475,18 +475,18 @@ class Clique:
                 return clique_head.head
         raise ValueError(f"Could not find matching clique for Pauli, {pauli}")
 
-    def get_empty_heads(self, mitigation_int) -> list[str]:
-        """Return all heads that do not have any data for a specific mitigation int.
+    def get_empty_heads(self, mitigation_flags: MitigationFlags | None = None) -> list[str]:
+        """Return all heads that do not have data for a mitigation configuration.
 
         Args:
-            mitigation_int: Mitigation integer, default is 0.
+            mitigation_flags: Mitigation flags object, default is None.
 
         Returns:
-            List of heads that have no data for the given mitigation integer.
+            List of heads that have no data for the given mitigation configuration.
         """
         empties = []
         for clique_head in self.cliques:
-            if clique_head.distr.is_empty(mitigation_int):
+            if clique_head.distr.is_empty(mitigation_flags):
                 empties.append(clique_head.head)
         return empties
 


### PR DESCRIPTION
Bug: If you load saved Paulis that are from a M0 mitigation only (no post selection - PS) and then want to do M0+PS, SlowQuant erroneously runs M0 characterization again. 
This has been fixed now. 